### PR TITLE
feat: add admin docs for CVMs

### DIFF
--- a/admin/environment-management/cvms.md
+++ b/admin/environment-management/cvms.md
@@ -10,7 +10,7 @@ programs inside their Environment including Docker and systemd.
 
 Navigate to **Manage > Admin > General** to enable this option.
 
-## Infrastructure requirements
+## Infrastructure Requirements
 
 - The Kubernetes Nodes must have a minimum kernel version of `5.4`
 (released Nov 24th, 2019).

--- a/admin/environment-management/cvms.md
+++ b/admin/environment-management/cvms.md
@@ -1,0 +1,86 @@
+---
+title: Docker in Environments
+description: Learn how to enable support for secure Docker inside Environments. 
+---
+
+As a platform administrator, you have the option to enable
+[Container-based Virtual Machines](../../environments/cvms.md) as an Environment
+deployment option. This option allows users to run system-level
+programs inside their Environment including Docker and systemd.
+
+Navigate to **Manage > Admin > General** to enable this option.
+
+## Infrastructure requirements
+
+- The Kubernetes Nodes must have a minimum kernel version of `5.4`
+(released Nov 24th, 2019).
+- The Kubernetes Nodes must be running an Ubunutu OS.
+- Legacy versions of cluster-wide proxy services such as Istio are not
+supported.
+- The cluster must allow privileged containers and `hostPath` mounts. Read more
+about why this is still secure [here](#security).
+
+## Security
+
+The [Container-based Virtual Machine](../../environments/cvms.md) deployment
+option leverages the [sysbox container runtime](https://github.com/nestybox/sysbox)
+to offer a VM-like user experience with the footprint of a typical container.
+
+Coder first launches a supervising container with privileged. This container is
+standard and included as part of the Coder release package. As part of the
+Environment build process, the supervising container launches an inner container
+using the [sysbox container runtime](https://github.com/nestybox/sysbox).
+This inner container is the user’s [Environment](../../environments/index.md).
+The user cannot gain access to the supervising container at any point during the
+lifecycle of their Environment. The isolation between the user’s Environment
+container and it’s outer, supervising container is what provides
+[strong isolation](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/security.md).
+
+## Image Configuration
+
+### systemd
+
+During Environment startup, Coder checks for the presence of `/sbin/init` within
+the Environment Image. If the file exists, it's used as the container entrypoint
+with a `PID` of 1. If your image OS distribution does not link the `systemd`
+init to `/sbin/init`, you'll need to do this manually in your Dockerfile.
+
+The following snippet demonstrates how an image can specify `systemd` as the
+init.
+
+```Dockerfile
+FROM ubuntu:20.04
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    systemd
+
+# use systemd as the init
+RUN ln -s /lib/systemd/systemd /sbin/init
+```
+
+### Adding Docker
+
+Be sure to install the `docker` packages into your Environment Image. For a
+seamless experience, use [systemd](#systemd) and register the `docker` service
+so `dockerd` is automatically run during initialization.
+
+The following snippet demonstrates how an image can registry the `docker`
+service in it's Dockerfile.
+
+```Dockerfile
+FROM ubuntu:20.04
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    git \
+    bash \
+    docker.io \
+    curl \
+    sudo \
+    systemd
+
+# Enables Docker starting with systemd
+RUN systemctl enable docker
+
+# use systemd as the init
+RUN ln -s /lib/systemd/systemd /sbin/init
+```

--- a/admin/environment-management/cvms.md
+++ b/admin/environment-management/cvms.md
@@ -64,7 +64,7 @@ Be sure to install the `docker` packages into your Environment Image. For a
 seamless experience, use [systemd](#systemd) and register the `docker` service
 so `dockerd` is automatically run during initialization.
 
-The following snippet demonstrates how an image can registry the `docker`
+The following snippet demonstrates how an image can register the `docker`
 service in it's Dockerfile.
 
 ```Dockerfile

--- a/admin/environment-management/cvms.md
+++ b/admin/environment-management/cvms.md
@@ -14,7 +14,7 @@ Navigate to **Manage > Admin > General** to enable this option.
 
 - The Kubernetes Nodes must have a minimum kernel version of `5.4`
 (released Nov 24th, 2019).
-- The Kubernetes Nodes must be running an Ubunutu OS.
+- The Kubernetes Nodes must be running an Ubuntu OS.
 - Legacy versions of cluster-wide proxy services such as Istio are not
 supported.
 - The cluster must allow privileged containers and `hostPath` mounts. Read more

--- a/admin/environment-management/cvms.md
+++ b/admin/environment-management/cvms.md
@@ -65,7 +65,7 @@ seamless experience, use [systemd](#systemd) and register the `docker` service
 so `dockerd` is automatically run during initialization.
 
 The following snippet demonstrates how an image can register the `docker`
-service in it's Dockerfile.
+service in its Dockerfile.
 
 ```Dockerfile
 FROM ubuntu:20.04

--- a/environments/cvms.md
+++ b/environments/cvms.md
@@ -14,6 +14,10 @@ run Docker, Docker Compose, systemd, and other system-level applications
 securely within your development containers. We call this environment variant
 a *Container-based Virtual Machine (CVM)*.
 
+> Are you a platform admin? Learn how to
+[enable Docker in Environments](../admin/environment-management/cvms.md)
+for your deployment.
+
 ## Container-based Virtual Machine
 
 By choosing this option,
@@ -25,53 +29,6 @@ like Docker, check the `Run as Container-based Virtual Machine` box when you
 create a new Environment.
 
 ![Create CVM](../assets/cvm-create.png)
-
-## systemd
-
-During Environment startup, Coder checks for the presence of `/sbin/init` within
-the Environment Image. If the file exists, it's used as the container entrypoint
-with a `PID` of 1. If your image OS distribution does not link the `systemd`
-init to `/sbin/init`, you'll need to do this manually in your Dockerfile.
-
-The following snippet demonstrates how an image can specify `systemd` as the
-init.
-
-```Dockerfile
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    systemd
-
-# use systemd as the init
-RUN ln -s /lib/systemd/systemd /sbin/init
-```
-
-## Adding Docker
-
-Be sure to install the `docker` packages into your Environment Image. For a
-seamless experience, use [systemd](#systemd) and register the `docker` service
-so `dockerd` is automatically run during initialization.
-
-The following snippet demonstrates how an image can registry the `docker`
-service in it's Dockerfile.
-
-```Dockerfile
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    bash \
-    docker.io \
-    curl \
-    sudo \
-    systemd
-
-# Enables Docker starting with systemd
-RUN systemctl enable docker
-
-# use systemd as the init
-RUN ln -s /lib/systemd/systemd /sbin/init
-```
 
 ## Disk
 

--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,7 @@
           "path": "./admin/environment-management/index.md",
           "children": [
             { "path": "./admin/environment-management/shutdown.md" },
+            { "path": "./admin/environment-management/cvms.md" },
             { "path": "./admin/environment-management/gpu-acceleration.md" },
             { "path": "./admin/environment-management/privileged.md" },
             { "path": "./admin/environment-management/ssh-access.md" }


### PR DESCRIPTION
This will replace the existing CVM article in the help center. We can follow-up this PR with cloud-specific deployment docs in the help center and link to them from here.