### PR TITLE
Add system requirements for JetBrains editors

### DIFF
--- a/environments/editors.md
+++ b/environments/editors.md
@@ -51,7 +51,9 @@ launch the editor from the dashboard.
 
 ### System requirements
 
-For the best possible experience it is recommended to run the editor in an environment with:
+For the best possible experience it is recommended to run the editor in an 
+environment with:
+
 - at least 8 Gb of RAM
 - a CPU with at least 4 cores
 

--- a/environments/editors.md
+++ b/environments/editors.md
@@ -51,7 +51,7 @@ launch the editor from the dashboard.
 
 ### System requirements
 
-For the best possible experience it is recommended to run the editor in an 
+For the best possible experience it is recommended to run the editor in an
 environment with:
 
 - at least 8 Gb of RAM

--- a/environments/editors.md
+++ b/environments/editors.md
@@ -49,13 +49,13 @@ launch the editor from the dashboard.
 > If you need a valid license to run your IDE locally, you'll also need one to
 > run it in Coder.
 
-### System requirements
+### System Requirements
 
 For the best possible experience it is recommended to run the editor in an
-environment with:
+environment with at minimum the following resources:
 
-- at least 8 Gb of RAM
-- a CPU with at least 4 cores
+- 8 GB RAM
+- 4 CPU cores
 
 ### Known Issues
 

--- a/environments/editors.md
+++ b/environments/editors.md
@@ -49,6 +49,12 @@ launch the editor from the dashboard.
 > If you need a valid license to run your IDE locally, you'll also need one to
 > run it in Coder.
 
+### System requirements
+
+For the best possible experience it is recommended to run the editor in an environment with:
+- at least 8 Gb of RAM
+- a CPU with at least 4 cores
+
 ### Known Issues
 
 - Window dragging behavior can misalign with mouse movements


### PR DESCRIPTION
[ch2111] warn users about low resources

The recommendation is to have at leat 8 Gb of RAM
and 4 cores available to run projector and IntelliJ

![image](https://user-images.githubusercontent.com/1479167/103826158-f6b39e00-507e-11eb-8a36-24092a426871.png)
