### PR TITLE
Replace helm command with upgrade and specify repo

### DIFF
--- a/admin/devurls.md
+++ b/admin/devurls.md
@@ -25,7 +25,7 @@ in your cluster, you'll need to modify your:
 Set `devurls.host` to a wildcard domain pointing to your ingress controller:
 
 ```shell
-helm install coder --set devurls.host="*.my-custom-domain.io"
+helm upgrade coder coder/coder --set devurls.host="*.my-custom-domain.io"
 ```
 
 If you're using the default ingress controller, specifying a value for


### PR DESCRIPTION
This replaces the command we call out in the `devurls` setup as we are saying we are modifying helm, but then run the `install` command. This changes it to an `upgrade`, and adds the repo.