### PR TITLE
Fix deploy-preview to allow `/` in branch name

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -2,7 +2,7 @@ name: Deploy (Preview)
 on:
   push:
     branches:
-      - "**"
+      - "*"
       - "!master"
 jobs:
   preview:


### PR DESCRIPTION
This fixes the match criteria for branches to allow a `/` in the branch name, i.e. `iamhughes/test`

[See filter pattern cheat sheet](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet) for more info.