### PR TITLE
add info about trying coder

### DIFF
--- a/comparison.md
+++ b/comparison.md
@@ -66,4 +66,4 @@ development operations and cloud resources.
     </tr>
 </table>
 
-> For infomation about trying Coder, visit [https://coder.com/trial](https://coder.com/trial)
+> To get a free trial of Coder, please visit [https://coder.com/trial](https://coder.com/trial).

--- a/comparison.md
+++ b/comparison.md
@@ -65,3 +65,5 @@ development operations and cloud resources.
         <td>Optional</td>
     </tr>
 </table>
+
+> For infomation about trying Coder, visit [https://coder.com/trial](https://coder.com/trial)

--- a/setup/configuration.md
+++ b/setup/configuration.md
@@ -19,6 +19,8 @@ Make sure you have the following information on hand:
   config. Your license should have been sent to you via email; if not, please
   reach out to your Coder sales representative.
 
+> If you do not have a license, you can try Coder for 60 days by generating a [free trial license](https://coder.com/trial).
+
 ### Creating Your License File
 
 Coder provides you with your licensing information, which looks like:

--- a/setup/configuration.md
+++ b/setup/configuration.md
@@ -19,7 +19,7 @@ Make sure you have the following information on hand:
   config. Your license should have been sent to you via email; if not, please
   reach out to your Coder sales representative.
 
-> If you do not have a license, you can try Coder for 60 days by generating a [free trial license](https://coder.com/trial).
+> If you do not have a license, you can [generate one](https://coder.com/trial) that allows you to try Coder free of charge for 60 days.
 
 ### Creating Your License File
 

--- a/setup/index.md
+++ b/setup/index.md
@@ -4,6 +4,6 @@ description: Learn how to set up a Coder instance.
 icon: <svg class="MuiSvgIcon-root jss172" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"></path></svg>
 ---
 
-Coder is free to try! If you don't have a license, you can [generate a 60 day license](https://coder.com/trial). You can also try Coder with our [local preview script](kubernetes/local-preview) without a license.
+Coder is free to try! You can [generate a license](https://coder.com/trial) that allows you to try Coder free of charge for 60 days, or you can use our [local preview](kubernetes/local-preview) option.
 
 <children></children>

--- a/setup/index.md
+++ b/setup/index.md
@@ -4,4 +4,6 @@ description: Learn how to set up a Coder instance.
 icon: <svg class="MuiSvgIcon-root jss172" focusable="false" viewBox="0 0 24 24" aria-hidden="true"><path d="M22.7 19l-9.1-9.1c.9-2.3.4-5-1.5-6.9-2-2-5-2.4-7.4-1.3L9 6 6 9 1.6 4.7C.4 7.1.9 10.1 2.9 12.1c1.9 1.9 4.6 2.4 6.9 1.5l9.1 9.1c.4.4 1 .4 1.4 0l2.3-2.3c.5-.4.5-1.1.1-1.4z"></path></svg>
 ---
 
+Coder is free to try! If you don't have a license, you can [generate a 60 day license](https://coder.com/trial). You can also try Coder with our [local preview script](kubernetes/local-preview) without a license.
+
 <children></children>


### PR DESCRIPTION
- As someone evaluating Coder, I should know that Coder has a 60 day trial license that can be immediately generated on https://coder.com/trial
- As someone evaluating Coder, I should know that Coder has a "local preview" option that is documented [here](https://codercom-km0xqlzsl.vercel.app/docs/setup/kubernetes/local-preview) (#68) and does not require a license.  

I am thinking that this info should probably be root level with some text in the [Setup](https://coder.com/docs/setup) page so the user doesn't have to do a lot of clicking around. Let me know if you think another hierarchy would be better.

I like how Okteto does this: https://okteto.com/docs/enterprise/install/overview.

⚠️ Do not merge until #68 is merged.