### PR TITLE
attempt to fix deploy previews on forks

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - "**"
       - "!master"
+    pull_request:
+      branches:
+        - "**"
 jobs:
   preview:
     name: Preview


### PR DESCRIPTION
my latest two prs (#97 and #94) did not run the action. I wasn't sure if it was intentional or not to disable previews from forks.

ref: https://futurestud.io/tutorials/github-actions-run-on-pull-request

We could potentially limit to PRs against master.