### PR TITLE
clarify personalize commands

### DIFF
--- a/environments/personalization.md
+++ b/environments/personalization.md
@@ -45,6 +45,9 @@ the build log.
 
 ![Enable privileged environment](../assets/personalize-log.png)
 
+**Note:** The `-y` flag is required to continue through any prompts.
+Otherwise, the `~/personalize` script will abort.
+
 ## Git Integration
 
 Once your site manager has [set up a Git service](../admin/git.md), you can link

--- a/environments/personalization.md
+++ b/environments/personalization.md
@@ -40,13 +40,13 @@ sudo apt-get install -y fish
 sudo chsh -s /usr/bin/fish $USER
 ```
 
+**Note:** The `-y` flag is required to continue through any prompts.
+Otherwise, the `~/personalize` script will abort.
+
 The Environments page shows the log output of the `~/personalize` script in
 the build log.
 
 ![Enable privileged environment](../assets/personalize-log.png)
-
-**Note:** The `-y` flag is required to continue through any prompts.
-Otherwise, the `~/personalize` script will abort.
 
 ## Git Integration
 


### PR DESCRIPTION
hey @khorne3 - i noticed that the ~/personalize script will abort if there is no -y flag when a command is run. i added the following lines to clarify this for users. let me know what you think.