### PR TITLE
Fix: Remove `pull_request` event from preview deploys

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -20,8 +20,13 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           submodules: true
           fetch-depth: 0
-      - name: Checkout Docs
+      - name: Checkout Docs - Push
+        if: ${{ github.event_name == 'push'}}
         run: git fetch && git checkout ${GITHUB_SHA}
+        working-directory: ./product/coder.com/site/docs
+      - name: Checkout Docs - Pull Request
+        if: ${{ github.event_name == 'pull_request'}}
+        run: git fetch && git checkout ${GITHUB_HEAD_REF}
         working-directory: ./product/coder.com/site/docs
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -24,7 +24,7 @@ jobs:
         if: ${{ github.event_name == 'push'}}
         run: git fetch && git checkout ${GITHUB_SHA}
         working-directory: ./product/coder.com/site/docs
-      - name: Checkout Docs - Pull Request
+      - name: Checkout Docs - PR
         if: ${{ github.event_name == 'pull_request'}}
         run: git fetch && git checkout ${GITHUB_HEAD_REF}
         working-directory: ./product/coder.com/site/docs

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Checkout Docs
-        run: git fetch && git checkout ${GITHUB_SHA}
+        run: git fetch && git checkout ${GITHUB_REF}
         working-directory: ./product/coder.com/site/docs
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,6 +11,8 @@ jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
+    # Prevent duplicate run from happening when a forked push is committed
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout Mono
         uses: actions/checkout@v2

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -4,15 +4,10 @@ on:
     branches:
       - "**"
       - "!master"
-  pull_request:
-    branches:
-      - "**"
 jobs:
   preview:
     name: Preview
     runs-on: ubuntu-latest
-    # Prevent duplicate run from happening when a forked push is committed
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout Mono
         uses: actions/checkout@v2
@@ -22,13 +17,8 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           submodules: true
           fetch-depth: 0
-      - name: Checkout Docs - Push
-        if: ${{ github.event_name == 'push'}}
+      - name: Checkout Docs
         run: git fetch && git checkout ${GITHUB_SHA}
-        working-directory: ./product/coder.com/site/docs
-      - name: Checkout Docs - PR
-        if: ${{ github.event_name == 'pull_request'}}
-        run: git fetch && git checkout ${GITHUB_HEAD_REF}
         working-directory: ./product/coder.com/site/docs
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -21,7 +21,7 @@ jobs:
           submodules: true
           fetch-depth: 0
       - name: Checkout Docs
-        run: git fetch && git checkout ${GITHUB_REF}
+        run: git fetch && git checkout ${GITHUB_SHA}
         working-directory: ./product/coder.com/site/docs
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -4,9 +4,9 @@ on:
     branches:
       - "**"
       - "!master"
-    pull_request:
-      branches:
-        - "**"
+  pull_request:
+    branches:
+      - "**"
 jobs:
   preview:
     name: Preview


### PR DESCRIPTION
`pull_request` was added as an event type to trigger deploys to preview from forks to assist with the OSS contribution process. Unfortunately, we depend on a secret to access a private repository which is NOT passed to the fork for security purposes (GitHub security enforces this). Therefore, I'm removing the `pull_request` event entirely which should fix the issues we were seeing.

Note: Pushes to branches in PRs will still trigger builds