### PR TITLE
fix: pwd reset link

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -106,9 +106,8 @@ kubectl config set-context --current --namespace=coder
    These are the credentials you need to continue setup using Coder's web UI.
 
 > If you lose your admin credentials, you can use the [admin password
-> reset](https://coder.com/docs/admin/access-control/password-reset#resetting-the-site-admin-password)
-process to
-> regain access.
+> reset](../admin/access-control/password-reset.md#resetting-the-site-admin-password)
+> process to regain access.
 
 ## Accessing Coder
 

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -106,7 +106,8 @@ kubectl config set-context --current --namespace=coder
    These are the credentials you need to continue setup using Coder's web UI.
 
 > If you lose your admin credentials, you can use the [admin password
-> reset](https://help.coder.com/hc/en-us/articles/360057772573) process to
+> reset](https://coder.com/docs/admin/access-control/password-reset#resetting-the-site-admin-password)
+process to
 > regain access.
 
 ## Accessing Coder


### PR DESCRIPTION
admin reset password link was redirecting to the help center. updated the link to redirect to the admin password reset on `docs`.