### PR TITLE
Calico uses calico-system namespace now

### DIFF
--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -172,13 +172,13 @@ implement network segmentation and tenant isolation.
 1. Apply the Calico manifest to your cluster:
 
    ```bash
-   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.5/config/v1.7/calico.yaml
+   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.9/config/v1.7/calico.yaml
    ```
 
 1. Watch the `kube-system` DaemonSets:
 
    ```bash
-   kubectl get daemonset calico-node --namespace kube-system
+   kubectl get daemonset calico-node --namespace calico-system 
    ```
 
    Wait for the `calico-node` DaemonSet to have the number of pods **desired**

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -175,7 +175,7 @@ implement network segmentation and tenant isolation.
    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.7.9/config/v1.7/calico.yaml
    ```
 
-1. Watch the `kube-system` DaemonSets:
+1. Watch the `calico-system` DaemonSets:
 
    ```bash
    kubectl get daemonset calico-node --namespace calico-system 


### PR DESCRIPTION
Just went through the install the kube-system had no signs of calico but the shiny new calico-system namespace was full of goodies. 