### PR TITLE
fix(docs): Consolidate Dev URL(s) naming

### DIFF
--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -116,7 +116,7 @@ when communicating with the Coder deployment.
    Optionally, you can provide additional helm configuration values by providing
    a `values.yaml` file and adding the argument `-f my-values.yaml` to the
    generated command. Helm values control attributes of the workspace provider,
-   including DevURLs, Kubernetes storage classes, SSH, and more. See the
+   including Dev URLs, Kubernetes storage classes, SSH, and more. See the
    [Workspace Provider Helm Chart
    Values]("https://github.com/cdr/enterprise-helm/blob/workspace-providers-envproxy-only/README.md")
    for more details.

--- a/changelog/1.13.2.md
+++ b/changelog/1.13.2.md
@@ -9,7 +9,7 @@ There are no breaking changes in 1.13.2.
 
 ### Features ✨
 
-- infra: Adds support for `https` servers behind DevURLs
+- infra: Adds support for `https` servers behind Dev URLs
   - **Notice:** Environments will need to be rebuilt before using this feature
 
 ### Bug Fixes 🐛

--- a/environments/devurls.md
+++ b/environments/devurls.md
@@ -6,7 +6,7 @@ description: Learn how to access HTTP services running inside your Environment.
 Developer (Dev) URLs allow you to access the web services you're developing in
 your environment.
 
-> You must have [DevURLs enabled](../admin/devurls.md) in your installation.
+> You must have [Dev URLs enabled](../admin/devurls.md) in your installation.
 
 ## Creating a Dev URL
 
@@ -17,7 +17,7 @@ number you want to be used and a friendly **name** for the URL (optional). Next,
 indicate who can **access** the URL and the **internal server scheme** (e.g., whether
 Coder should use HTTP or HTTPS when proxying requests to the internal server).
 
-![Create a DevURL](../assets/create-devurl.png)
+![Create a Dev URL](../assets/create-devurl.png)
 
 ## Access Control
 
@@ -37,11 +37,11 @@ To access a Dev URL, you can click:
 - The **Open in browser** icon to launch a new browser window
 - The **Copy** button to copy the URL for sharing
 
-![DevURLs List](../assets/devurls.png)
+![Dev URLs List](../assets/devurls.png)
 
 ### Direct Access
 
-There are two ways for you to construct DevURLs.
+There are two ways for you to construct Dev URLs.
 
 If you provided a name for the Dev URL when you created it:
 


### PR DESCRIPTION
We refer to Developer URLs as two words, both capitalized: `Dev URL(s)`. I found various cases where the two words were combined into one, which is inconsistent with most other cases and the product UI.