### PR TITLE
add: cluster deploy timelines

### DIFF
--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -91,7 +91,7 @@ When your cluster is ready, you should see the following message:
 EKS cluster "YOUR_CLUSTER_NAME" in "YOUR_REGION" region is ready
 ```
 
-This process might take roughly ~15-30 minutes to complete.
+This process may take ~15-30 minutes to complete.
 
 ## Step 2: Adjust the K8 Storage Class
 

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -91,6 +91,8 @@ When your cluster is ready, you should see the following message:
 EKS cluster "YOUR_CLUSTER_NAME" in "YOUR_REGION" region is ready
 ```
 
+This process might take roughly ~15-30 minutes to complete.
+
 ## Step 2: Adjust the K8 Storage Class
 
 Once you've created the cluster, adjust the default Kubernetes storage class to

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -78,7 +78,7 @@ gcloud beta container --project "$PROJECT_ID" \
     --max-nodes "8"
 ```
 
-This process might take roughly ~15-30 minutes to complete.
+This process may take ~15-30 minutes to complete.
 
 ## Access Control
 

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -78,6 +78,8 @@ gcloud beta container --project "$PROJECT_ID" \
     --max-nodes "8"
 ```
 
+This process might take roughly ~15-30 minutes to complete.
+
 ## Access Control
 
 GKE allows you to integrate Identity Access and Management (IAM) with


### PR DESCRIPTION
adding deploy timeline estimates for AWS & GCP, to keep with timeline currently included on Azure docs. also will be helpful in giving context to customers who are new to K8s.