### PR TITLE
clarify supported git providers

### DIFF
--- a/admin/git.md
+++ b/admin/git.md
@@ -17,6 +17,9 @@ Currently, Coder supports the following providers:
   rel="noreferrer noopener">doesn't support</a> managing SSH keys for users via
   OAuth)
 
+**Note:** Utilizing one of the above git providers via OAuth integration isn't required.
+You can use any git provider of choice given you manage your own SSH keys. 
+
 ![Configure Git Integration](../assets/git-admin.png)
 
 ## Configuring OAuth

--- a/admin/git.md
+++ b/admin/git.md
@@ -8,7 +8,8 @@ their accounts with the Git repository service of choice.
 
 ## Support
 
-Currently, Coder integrates with the following git providers:
+Coder integrates with the following service providers for authentication and
+[user key management](https://coder.com/docs/environments/preferences#linked-accounts):
 
 - GitHub (both GitHub.com and GitHub Enterprise)
 - GitLab (both GitLab.com and self-hosted GitLab)
@@ -17,8 +18,11 @@ Currently, Coder integrates with the following git providers:
   rel="noreferrer noopener">doesn't support</a> managing SSH keys for users via
   OAuth)
 
-> You can use any git provider of choice. Configuring a git integration provides
-a user experience improvement but is not required.
+Note that linking your Coder account with a git service provider is *not*
+required. Instead, you can use Visual Studio Code with git, the command-line
+tool, and we expect that this combination will work with most hosting software
+or services. However, Coder doesn't test these and cannot provide
+recommendations or support.
 
 ![Configure Git Integration](../assets/git-admin.png)
 

--- a/admin/git.md
+++ b/admin/git.md
@@ -8,7 +8,7 @@ their accounts with the Git repository service of choice.
 
 ## Support
 
-Currently, Coder supports the following providers:
+Currently, Coder integrates with the following git providers:
 
 - GitHub (both GitHub.com and GitHub Enterprise)
 - GitLab (both GitLab.com and self-hosted GitLab)
@@ -17,8 +17,8 @@ Currently, Coder supports the following providers:
   rel="noreferrer noopener">doesn't support</a> managing SSH keys for users via
   OAuth)
 
-**Note:** Utilizing one of the above git providers via OAuth integration isn't required.
-You can use any git provider of choice given you manage your own SSH keys. 
+> You can use any git provider of choice. Configuring a git integration provides
+a user experience improvement but is not required.
 
 ![Configure Git Integration](../assets/git-admin.png)
 


### PR DESCRIPTION
adding this clarification, as it's come in up a [slack thread](https://codercom.slack.com/archives/C014JH42DBJ/p1616584356048200) that users can utilize any git provider, as long as they manage their own SSH keys. users are only limited to the three listed git providers if they expect to configure a git integration via OAuth.