### PR TITLE
clarify network policy implementations

### DIFF
--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -56,6 +56,9 @@ CLUSTER_NAME="<MY_CLUSTER_NAME>" SUBSCRIPTION="<MY_SUBSCRIPTION_SHA>"
 
 Create the Azure Kubernetes Service Cluster:
 
+**Note:** AKS has built-in support for the [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke) network policy engine. It can only be enabled when the cluster is created. You can't
+enable Calico on an existing AKS cluster.
+
 ```console
 # You may have to run `az extension add --name aks-preview`
 #

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -56,8 +56,10 @@ CLUSTER_NAME="<MY_CLUSTER_NAME>" SUBSCRIPTION="<MY_SUBSCRIPTION_SHA>"
 
 Create the Azure Kubernetes Service Cluster:
 
-**Note:** AKS has built-in support for the [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke) network policy engine. It can only be enabled when the
-cluster is created. You can't enable Calico on an existing AKS cluster.
+**Note:** AKS has built-in support for the
+[Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke)
+network policy engine. It can only be enabled when the cluster is created.
+You can't enable Calico on an existing AKS cluster.
 
 ```console
 # You may have to run `az extension add --name aks-preview`

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -56,11 +56,6 @@ CLUSTER_NAME="<MY_CLUSTER_NAME>" SUBSCRIPTION="<MY_SUBSCRIPTION_SHA>"
 
 Create the Azure Kubernetes Service Cluster:
 
-**Note:** AKS has built-in support for the
-[Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke)
-network policy engine. It can only be enabled when the cluster is created.
-You can't enable Calico on an existing AKS cluster.
-
 ```console
 # You may have to run `az extension add --name aks-preview`
 #
@@ -82,6 +77,14 @@ az aks create \
   --network-plugin "kubenet" \
   --network-policy "calico"
 ```
+
+> [AKS offers built-in
+support](https://docs.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy)
+for the
+[Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke)
+network policy engine. However, you can only choose Calico as your network
+policy option when you create the cluster; you cannot enable Calico on an
+existing cluster.
 
 This process might take some time (~5-20 minutes), but if you're successful,
 Azure returns a JSON object with your cluster information.

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -82,9 +82,11 @@ az aks create \
 support](https://docs.microsoft.com/en-us/azure/aks/use-network-policies#create-an-aks-cluster-and-enable-network-policy)
 for the
 [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke)
-network policy engine. However, you can only choose Calico as your network
-policy option when you create the cluster; you cannot enable Calico on an
-existing cluster.
+network policy engine, and you can opt-in by including the `--network-policy
+"calico"` flag.
+>
+> However, you can only choose Calico as your network policy option when you
+create the cluster; you cannot enable Calico on an existing cluster.
 
 This process might take some time (~5-20 minutes), but if you're successful,
 Azure returns a JSON object with your cluster information.

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -56,8 +56,8 @@ CLUSTER_NAME="<MY_CLUSTER_NAME>" SUBSCRIPTION="<MY_SUBSCRIPTION_SHA>"
 
 Create the Azure Kubernetes Service Cluster:
 
-**Note:** AKS has built-in support for the [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke) network policy engine. It can only be enabled when the cluster is created. You can't
-enable Calico on an existing AKS cluster.
+**Note:** AKS has built-in support for the [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke) network policy engine. It can only be enabled when the
+cluster is created. You can't enable Calico on an existing AKS cluster.
 
 ```console
 # You may have to run `az extension add --name aks-preview`

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -18,6 +18,8 @@ The following will spin up a Kubernetes cluster using the `gcloud` command (be
 sure to replace the parameters (specifically `PROJECT_ID`,
 `NEW_CLUSTER_NAME`, and `ZONE`) as needed to reflect the needs of your environment).
 
+**Note:** By including `enable-network-policy` below, GKE will deploy [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke) by default.
+
 ```console
 gcloud beta container --project "$PROJECT_ID" \
 clusters create "$NEW_CLUSTER_NAME" \

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -18,7 +18,9 @@ The following will spin up a Kubernetes cluster using the `gcloud` command (be
 sure to replace the parameters (specifically `PROJECT_ID`,
 `NEW_CLUSTER_NAME`, and `ZONE`) as needed to reflect the needs of your environment).
 
-**Note:** By including `enable-network-policy` below, GKE will deploy [Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke) by default.
+**Note:** By including `enable-network-policy` below, GKE will deploy
+[Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke)
+by default.
 
 ```console
 gcloud beta container --project "$PROJECT_ID" \

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -18,10 +18,6 @@ The following will spin up a Kubernetes cluster using the `gcloud` command (be
 sure to replace the parameters (specifically `PROJECT_ID`,
 `NEW_CLUSTER_NAME`, and `ZONE`) as needed to reflect the needs of your environment).
 
-**Note:** By including `enable-network-policy` below, GKE will deploy
-[Calico](https://docs.projectcalico.org/getting-started/kubernetes/managed-public-cloud/gke)
-by default.
-
 ```console
 gcloud beta container --project "$PROJECT_ID" \
 clusters create "$NEW_CLUSTER_NAME" \
@@ -49,6 +45,10 @@ clusters create "$NEW_CLUSTER_NAME" \
    --min-nodes "1" \
    --max-nodes "8"
 ```
+
+> The example above includes the use of the `enable-network-policy` flag, which will
+result in the [creation of a Calico
+cluster](https://kubernetes.io/docs/tasks/administer-cluster/network-policy-provider/calico-network-policy/).
 
 To create clusters capable of supporting use of the
 [CVMs](../../admin/environment-management/cvms.md) deployment option:


### PR DESCRIPTION
did some reading on network policy stuff, and learned that google enables Calico by default when `enable-network-policy` is included in the create cluster command. added this clarification for GCP.

additionally, azure has built-in support for calico, and users can _only_ enable it upon cluster creation. added this clarification
as well, since we make no mention of Calico, outside of the `network-policy "calico"` line in the create cluster command.

open to thoughts & feedback.