### PR TITLE
chore: Automate adding clog to manifest

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "printWidth": 80,
+  "semi": false,
+
   "overrides": [
     {
       "files": ["*.md"],

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,15 @@
     {
       "path": "./index.md",
       "children": [
-        { "path": "about.md" },
-        { "path": "comparison.md" },
-        { "path": "feedback.md" }
+        {
+          "path": "about.md"
+        },
+        {
+          "path": "comparison.md"
+        },
+        {
+          "path": "feedback.md"
+        }
       ]
     },
     {
@@ -34,43 +40,87 @@
     {
       "path": "./images/index.md",
       "children": [
-        { "path": "./images/importing.md" },
-        { "path": "./images/structure.md" },
-        { "path": "./images/tags.md" },
-        { "path": "./images/configure.md" },
-        { "path": "./images/ssl-certificates.md" },
-        { "path": "./images/deprecating.md" },
-        { "path": "./images/embed-button.md" }
+        {
+          "path": "./images/importing.md"
+        },
+        {
+          "path": "./images/structure.md"
+        },
+        {
+          "path": "./images/tags.md"
+        },
+        {
+          "path": "./images/configure.md"
+        },
+        {
+          "path": "./images/ssl-certificates.md"
+        },
+        {
+          "path": "./images/deprecating.md"
+        },
+        {
+          "path": "./images/embed-button.md"
+        }
       ]
     },
     {
       "path": "./cli/index.md",
       "children": [
-        { "path": "./cli/installation.md" },
-        { "path": "./cli/remote-terminal.md" },
-        { "path": "./cli/file-sync.md" },
-        { "path": "./cli/managing-envs.md" }
+        {
+          "path": "./cli/installation.md"
+        },
+        {
+          "path": "./cli/remote-terminal.md"
+        },
+        {
+          "path": "./cli/file-sync.md"
+        },
+        {
+          "path": "./cli/managing-envs.md"
+        }
       ]
     },
     {
       "path": "./setup/index.md",
       "children": [
-        { "path": "./setup/architecture.md" },
-        { "path": "./setup/requirements.md" },
+        {
+          "path": "./setup/architecture.md"
+        },
+        {
+          "path": "./setup/requirements.md"
+        },
         {
           "path": "./setup/kubernetes/index.md",
           "children": [
-            { "path": "./setup/kubernetes/local-preview.md" },
-            { "path": "./setup/kubernetes/aws.md" },
-            { "path": "./setup/kubernetes/azure.md" },
-            { "path": "./setup/kubernetes/google.md" }
+            {
+              "path": "./setup/kubernetes/local-preview.md"
+            },
+            {
+              "path": "./setup/kubernetes/aws.md"
+            },
+            {
+              "path": "./setup/kubernetes/azure.md"
+            },
+            {
+              "path": "./setup/kubernetes/google.md"
+            }
           ]
         },
-        { "path": "./setup/installation.md" },
-        { "path": "./setup/configuration.md" },
-        { "path": "./setup/licensing.md" },
-        { "path": "./setup/air-gapped.md" },
-        { "path": "./setup/updating.md" }
+        {
+          "path": "./setup/installation.md"
+        },
+        {
+          "path": "./setup/configuration.md"
+        },
+        {
+          "path": "./setup/licensing.md"
+        },
+        {
+          "path": "./setup/air-gapped.md"
+        },
+        {
+          "path": "./setup/updating.md"
+        }
       ]
     },
     {
@@ -79,31 +129,53 @@
         {
           "path": "./admin/access-control/index.md",
           "children": [
-            { "path": "./admin/access-control/user-roles.md" },
-            { "path": "./admin/access-control/organizations.md" },
-            { "path": "./admin/access-control/password-reset.md" },
-            { "path": "./admin/access-control/user-management.md" }
+            {
+              "path": "./admin/access-control/user-roles.md"
+            },
+            {
+              "path": "./admin/access-control/organizations.md"
+            },
+            {
+              "path": "./admin/access-control/password-reset.md"
+            },
+            {
+              "path": "./admin/access-control/user-management.md"
+            }
           ]
         },
         {
           "path": "./admin/environment-management/index.md",
           "children": [
-            { "path": "./admin/environment-management/cvms.md" },
-            { "path": "./admin/environment-management/extensions.md" },
-            { "path": "./admin/environment-management/gpu-acceleration.md" },
+            {
+              "path": "./admin/environment-management/cvms.md"
+            },
+            {
+              "path": "./admin/environment-management/extensions.md"
+            },
+            {
+              "path": "./admin/environment-management/gpu-acceleration.md"
+            },
             {
               "path": "./admin/environment-management/installing-jetbrains.md"
             },
             {
               "path": "./admin/environment-management/memory-overprovisioning.md"
             },
-            { "path": "./admin/environment-management/shutdown.md" },
-            { "path": "./admin/environment-management/ssh-access.md" }
+            {
+              "path": "./admin/environment-management/shutdown.md"
+            },
+            {
+              "path": "./admin/environment-management/ssh-access.md"
+            }
           ]
         },
         {
           "path": "./admin/registries/index.md",
-          "children": [{ "path": "./admin/registries/default-registry.md" }]
+          "children": [
+            {
+              "path": "./admin/registries/default-registry.md"
+            }
+          ]
         },
         {
           "path": "./admin/workspace-providers/index.md",
@@ -127,44 +199,74 @@
           "path": "./guides/admin/index.md",
           "navigable": false,
           "children": [
-            { "path": "./guides/admin/resources.md" },
-            { "path": "./guides/admin/usage-monitoring.md" },
-            { "path": "./guides/admin/helm-charts.md" }
+            {
+              "path": "./guides/admin/resources.md"
+            },
+            {
+              "path": "./guides/admin/usage-monitoring.md"
+            },
+            {
+              "path": "./guides/admin/helm-charts.md"
+            }
           ]
         },
         {
           "path": "./guides/customization/index.md",
           "navigable": false,
           "children": [
-            { "path": "./guides/customization/custom-env.md" },
-            { "path": "./guides/customization/gitconfig.md" },
-            { "path": "./guides/customization/macos-keybinding.md" }
+            {
+              "path": "./guides/customization/custom-env.md"
+            },
+            {
+              "path": "./guides/customization/gitconfig.md"
+            },
+            {
+              "path": "./guides/customization/macos-keybinding.md"
+            }
           ]
         },
         {
           "path": "./guides/deployments/index.md",
           "navigable": false,
           "children": [
-            { "path": "./guides/deployments/nightly-releases.md" },
-            { "path": "./guides/deployments/keycloak.md" },
-            { "path": "./guides/deployments/teardown.md" }
+            {
+              "path": "./guides/deployments/nightly-releases.md"
+            },
+            {
+              "path": "./guides/deployments/keycloak.md"
+            },
+            {
+              "path": "./guides/deployments/teardown.md"
+            }
           ]
         },
         {
           "path": "./guides/ssl-certificates/index.md",
           "navigable": false,
           "children": [
-            { "path": "./guides/ssl-certificates/cloudflare.md" },
-            { "path": "./guides/ssl-certificates/route53.md" }
+            {
+              "path": "./guides/ssl-certificates/cloudflare.md"
+            },
+            {
+              "path": "./guides/ssl-certificates/route53.md"
+            }
           ]
         },
-        { "path": "./guides/mobile-development/index.md", "navigable": false },
-        { "path": "./guides/api.md", "navigable": false },
+        {
+          "path": "./guides/mobile-development/index.md",
+          "navigable": false
+        },
+        {
+          "path": "./guides/api.md",
+          "navigable": false
+        },
         {
           "path": "./guides/troubleshooting/index.md",
           "navigable": false,
           "children": [
-            { "path": "./guides/troubleshooting/inotify-watch-limits.md" }
+            {
+              "path": "./guides/troubleshooting/inotify-watch-limits.md"
+            }
           ]
         }
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -17,22 +17,48 @@
     {
       "path": "./environments/index.md",
       "children": [
-        { "path": "./environments/getting-started.md" },
-        { "path": "./environments/lifecycle.md" },
-        { "path": "./environments/editors.md" },
-        { "path": "./environments/autostart.md" },
-        { "path": "./environments/devurls.md" },
-        { "path": "./environments/cvms.md" },
-        { "path": "./environments/environment-params.md" },
-        { "path": "./environments/variables.md" },
-        { "path": "./environments/personalization.md" },
-        { "path": "./environments/preferences.md" },
-        { "path": "./environments/pwa.md" },
-        { "path": "./environments/ssh.md" },
+        {
+          "path": "./environments/getting-started.md"
+        },
+        {
+          "path": "./environments/lifecycle.md"
+        },
+        {
+          "path": "./environments/editors.md"
+        },
+        {
+          "path": "./environments/autostart.md"
+        },
+        {
+          "path": "./environments/devurls.md"
+        },
+        {
+          "path": "./environments/cvms.md"
+        },
+        {
+          "path": "./environments/environment-params.md"
+        },
+        {
+          "path": "./environments/variables.md"
+        },
+        {
+          "path": "./environments/personalization.md"
+        },
+        {
+          "path": "./environments/preferences.md"
+        },
+        {
+          "path": "./environments/pwa.md"
+        },
+        {
+          "path": "./environments/ssh.md"
+        },
         {
           "path": "./environments/workspaces-as-code/index.md",
           "children": [
-            { "path": "./environments/workspaces-as-code/templates.md" }
+            {
+              "path": "./environments/workspaces-as-code/templates.md"
+            }
           ]
         }
       ]
@@ -179,16 +205,36 @@
         },
         {
           "path": "./admin/workspace-providers/index.md",
-          "children": [{ "path": "./admin/workspace-providers/deployment.md" }]
+          "children": [
+            {
+              "path": "./admin/workspace-providers/deployment.md"
+            }
+          ]
         },
-        { "path": "./admin/account-dormancy.md" },
-        { "path": "./admin/appearance.md" },
-        { "path": "./admin/audit.md" },
-        { "path": "./admin/devurls.md" },
-        { "path": "./admin/git.md" },
-        { "path": "./admin/metrics.md" },
-        { "path": "./admin/telemetry.md" },
-        { "path": "./admin/templates.md" }
+        {
+          "path": "./admin/account-dormancy.md"
+        },
+        {
+          "path": "./admin/appearance.md"
+        },
+        {
+          "path": "./admin/audit.md"
+        },
+        {
+          "path": "./admin/devurls.md"
+        },
+        {
+          "path": "./admin/git.md"
+        },
+        {
+          "path": "./admin/metrics.md"
+        },
+        {
+          "path": "./admin/telemetry.md"
+        },
+        {
+          "path": "./admin/templates.md"
+        }
       ]
     },
     {
@@ -274,22 +320,57 @@
     {
       "path": "./changelog/index.md",
       "children": [
-        { "path": "./changelog/1.17.2.md" },
-        { "path": "./changelog/1.17.1.md" },
-        { "path": "./changelog/1.17.0.md" },
-        { "path": "./changelog/1.16.3.md" },
-        { "path": "./changelog/1.16.2.md" },
-        { "path": "./changelog/1.16.1.md" },
-        { "path": "./changelog/1.16.0.md" },
-        { "path": "./changelog/1.15.2.md" },
-        { "path": "./changelog/1.15.1.md" },
-        { "path": "./changelog/1.15.0.md" },
-        { "path": "./changelog/1.14.4.md" },
-        { "path": "./changelog/1.14.3.md" },
-        { "path": "./changelog/1.14.2.md" },
-        { "path": "./changelog/1.14.1.md" },
-        { "path": "./changelog/1.14.0.md" },
-        { "path": "./changelog/1.13.2.md" }
+        {
+          "path": "./changelog/1.17.3.md"
+        },
+        {
+          "path": "./changelog/1.17.2.md"
+        },
+        {
+          "path": "./changelog/1.17.1.md"
+        },
+        {
+          "path": "./changelog/1.17.0.md"
+        },
+        {
+          "path": "./changelog/1.16.3.md"
+        },
+        {
+          "path": "./changelog/1.16.2.md"
+        },
+        {
+          "path": "./changelog/1.16.1.md"
+        },
+        {
+          "path": "./changelog/1.16.0.md"
+        },
+        {
+          "path": "./changelog/1.15.2.md"
+        },
+        {
+          "path": "./changelog/1.15.1.md"
+        },
+        {
+          "path": "./changelog/1.15.0.md"
+        },
+        {
+          "path": "./changelog/1.14.4.md"
+        },
+        {
+          "path": "./changelog/1.14.3.md"
+        },
+        {
+          "path": "./changelog/1.14.2.md"
+        },
+        {
+          "path": "./changelog/1.14.1.md"
+        },
+        {
+          "path": "./changelog/1.14.0.md"
+        },
+        {
+          "path": "./changelog/1.13.2.md"
+        }
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,20 +1,27 @@
 {
   "scripts": {
-    "fmt": "prettier --check '**/*.{json,md,yaml,yml}'",
-    "fmt:fix": "prettier --write '**/*.{json,md,yaml,yml}'",
+    "fmt": "prettier --check '**/*.{json,md,ts,yaml,yml}'",
+    "fmt:fix": "prettier --write '**/*.{json,md,ts,yaml,yml}'",
     "lint": "markdownlint '**/*.md'",
     "lint:fix": "markdownlint --fix '**/*.md'",
     "prepare": "husky install"
   },
   "devDependencies": {
+    "@types/minimist": "^1.2.1",
+    "@types/node": "^14.14.36",
+    "@types/semver-compare": "^1.0.1",
     "all-contributors-cli": "^6.20.0",
     "husky": "^6.0.0",
     "lint-staged": "^10.5.4",
     "markdownlint-cli": "^0.27.1",
-    "prettier": "^2.2.1"
+    "minimist": "^1.2.5",
+    "prettier": "^2.2.1",
+    "semver-compare": "^1.0.0",
+    "ts-node": "^9.1.1",
+    "typescript": "^4.2.3"
   },
   "lint-staged": {
-    "*.{json,yaml,yml}": "prettier --write",
+    "*.{json,ts,yaml,yml}": "prettier --write",
     "*.md": [
       "markdownlint --fix",
       "prettier --write"

--- a/scripts/add_clog_to_manifest.ts
+++ b/scripts/add_clog_to_manifest.ts
@@ -1,0 +1,96 @@
+/**
+ * @file add_clog_to_manifest.ts
+ * @description Adds a changelog entry to manifest.json
+ * @example add_clog_to_manifest.ts --version=1.18.3
+ */
+import { writeFileSync } from "fs"
+import parseArgs from "minimist"
+import { resolve } from "path"
+import semverCompare from "semver-compare"
+import manifestJSON from "../manifest.json"
+
+/**
+ * Prints information for how to use this program and exits with status code 1
+ */
+const usage = () => {
+  console.log("Usage: append_manifest.ts [--version=<version>]")
+  console.log("Update manifest.json with a changelog")
+  console.log("Arguments:")
+  console.log("    <version>: A version string 'x.y.z'")
+  process.exit(1)
+}
+
+interface Arguments {
+  /** A version string in the form of x.y.z. */
+  version?: string
+}
+
+/**
+ * Parses arguments
+ */
+const init = (): Arguments => {
+  const args = parseArgs(process.argv.slice(2))
+  const result: Arguments = {}
+  if (args.version && typeof args.version === "string") {
+    result.version = args.version
+  }
+  return result
+}
+
+/**
+ * Appends manifest.json with a changelog entry using the provided version
+ */
+const appendClogManifest = (version: string): void => {
+  const clogIdx = manifestJSON.routes.findIndex(
+    (route) => route.path === "./changelog/index.md"
+  )
+
+  if (clogIdx < 0) {
+    console.error("failed to parse manifest.json")
+    process.exit(1)
+  }
+
+  ;(manifestJSON.routes[clogIdx].children as { path: string }[]).unshift({
+    path: `./changelog/${version}.md`,
+  })
+
+  // Capture the semver version from /(1.2.3).md
+  const filenameRegex = /\/([0-9\.]+)\.md$/gi
+
+  manifestJSON.routes[clogIdx].children.sort((a, b) => {
+    const versionA = a.path.match(filenameRegex)
+    const versionB = b.path.match(filenameRegex)
+    if (
+      versionA === null ||
+      versionA.length !== 1 ||
+      versionB === null ||
+      versionB.length !== 1
+    ) {
+      console.error("failed to parse manifest.json")
+      process.exit(1)
+    }
+    return -semverCompare(versionA[0], versionB[0])
+  })
+
+  console.log("appending manifest.json with clog version: ", version)
+  const serializedJSON = JSON.stringify(manifestJSON, null, 2)
+  const manifestPath = resolve(__dirname, "../", "manifest.json")
+  writeFileSync(manifestPath, serializedJSON, "utf8")
+}
+
+/**
+ * Main program
+ */
+const main = () => {
+  const args = init()
+  if (!args.version) {
+    console.error("version is a required argument")
+    return usage()
+  }
+  appendClogManifest(args.version)
+  console.log("Done")
+  console.info("tip: run yarn fmt:fix to prettify manifest.json")
+  process.exit(0)
+}
+
+main()

--- a/scripts/create-clog.sh
+++ b/scripts/create-clog.sh
@@ -8,6 +8,7 @@
 #
 # Examples:
 #  ./scripts/create-clog.sh --version="1.18.0" --release-date="05/18/2021"
+#  ./scripts/create-clog.sh --version="1.18.0" --release-date=$(date +%D)
 
 
 set -eou pipefail
@@ -90,7 +91,16 @@ function create_from_template () {
   popd > /dev/null
 }
 
+# update_manifest calls a NodeJS script to update manifest.JSON using VERSION
+function update_manifest () {
+  echo "Calling add_clog_to_manifest.ts to update manifest.json"
+  pushd "$(git rev-parse --show-toplevel)" > /dev/null
+    ./node_modules/.bin/ts-node ./scripts/add_clog_to_manifest.ts --version="$VERSION"
+  popd > /dev/null
+}
+
 # main program
 init "$@"
 create_from_template
+update_manifest
 echo "Done"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "lib": [],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "target": "ES5"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,10 +30,25 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@types/minimist@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
+  integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+
+"@types/node@^14.14.36":
+  version "14.14.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.36.tgz#5637905dbb15c30a33a3c65b9ef7c20e3c85ebad"
+  integrity sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/semver-compare@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/semver-compare/-/semver-compare-1.0.1.tgz#17d1dc62c516c133ab01efb7803a537ee6eaf3d5"
+  integrity sha512-wx2LQVvKlEkhXp/HoKIZ/aSL+TvfJdKco8i0xJS3aR877mg4qBHzNT6+B5a61vewZHo79EdZavskGnRXEC2H6A==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -90,6 +105,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -124,6 +144,11 @@ braces@^3.0.1:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+buffer-from@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -241,6 +266,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.0:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -276,6 +306,11 @@ didyoumean@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
   integrity sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -639,6 +674,11 @@ log-update@^4.0.0:
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 markdown-it@12.0.4:
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.0.4.tgz#eec8247d296327eac3ba9746bdeec9cfcc751e33"
@@ -712,7 +752,7 @@ minimatch@^3.0.4, minimatch@~3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@~1.2.5:
+minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -968,6 +1008,19 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+source-map-support@^0.5.17:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 string-argv@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
@@ -1041,6 +1094,18 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -1050,6 +1115,11 @@ type-fest@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
+typescript@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.3.tgz#39062d8019912d43726298f09493d598048c1ce3"
+  integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -1125,3 +1195,8 @@ yargs@^15.0.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
## Context

In c886756b2783d1289eaaf96b950c05d02585e26b a clog generation script was added in order to help automate changelog generation. However, generated clogs still needed to be manually added to `manifest.json`. At the time, use of `jq` was experimented with in the `create-clog.sh` script, but was found to be not worth the effort.

## Summary

Adds a NodeJS script written in TS for adding changelog entries to `manifest.json`.

## Details

The `manifest.json` file was formatted as part of this diff because the `add_clog_to_manifest.ts` script uses `JSON.stringify` to serialize changes to JSON. The resulting format differed from our prior format, but still complies with prettier.

## Example

```console
$ ./scripts/create-clog.sh --version=1.18.2 --release-date=$(date +%D)
Creating template using version: 1.18.2 and release date: 03/26/21
Calling add_clog_to_manifest.ts to update manifest.json
appending manifest.json with clog version:  1.18.2
done
tip: run yarn fmt:fix to prettify manifest.json
Done
```

```bash
git diff
```

```diff
diff --git a/manifest.json b/manifest.json
index 12cfaf2..27b98c2 100644
--- a/manifest.json
+++ b/manifest.json
@@ -309,6 +309,9 @@
     {
       "path": "./changelog/index.md",
       "children": [
+        {
+          "path": "./changelog/1.18.2.md"
+        },
         {
           "path": "./changelog/1.17.1.md"
         },
```
