### PR TITLE
chore: use the same linter settings as the monorepo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,11 @@ jobs:
           node-version: 12.x
 
       - name: Install Node Modules
-        run: yarn
+        run: yarn install
 
       - name: Lint
-        run: |
-          yarn lint
-          yarn fmt
+        run: yarn lint
+
+      - name: Formatting
+        if: always()
+        run: yarn format:check

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "scripts": {
-    "fmt": "prettier --check '**/*.{json,md,ts,yaml,yml}'",
-    "fmt:fix": "prettier --write '**/*.{json,md,ts,yaml,yml}'",
+    "prepare": "husky install",
+    "format:check": "prettier --check '**/*.{css,html,js,json,jsx,ts,tsx,yaml,yml}'",
+    "format:write": "prettier --write '**/*.{css,html,js,json,jsx,ts,tsx,yaml,yml}'",
     "lint": "markdownlint '**/*.md'",
-    "lint:fix": "markdownlint --fix '**/*.md'",
-    "prepare": "husky install"
+    "lint:fix": "markdownlint --fix '**/*.md'"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
@@ -21,7 +21,9 @@
     "typescript": "^4.2.3"
   },
   "lint-staged": {
-    "*.{json,ts,yaml,yml}": "prettier --write",
+    "*.{css,html,js,json,jsx,ts,tsx,yaml,yml}": [
+      "prettier --write"
+    ],
     "*.md": [
       "markdownlint --fix",
       "prettier --write"


### PR DESCRIPTION
Use the same script names (e.g. yarn format:write) as we do in
the monorepo, so that it's easier to switch between projects.