### PR TITLE
chore: use hash of pull request head in preview message

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -73,5 +73,5 @@ jobs:
 
             * _Host_: ${{ steps.preview.outputs.url }}/docs
             * _Last deploy status_: ${{ steps.preview.outcome }}
-            * _Commit_: ${{ github.sha }}
+            * _Commit_: ${{ github.event.pull_request.head.sha }}
             * _Workflow status_: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Show the commit hash of the HEAD of the pull request, rather than
${{ github.sha }}, which is a strange internal hash.