### PR TITLE
Document network policy requirement [ch9751]

### DIFF
--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -45,17 +45,28 @@ launches the Remote IDE in a pop-up window.
 
 ## Network Policies
 
-Coder uses [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to enforce network segmentation and tenant isolation within your cluster. Coder's network isolation policy blocks all ingress traffic to workspaces, with the exception of traffic from the control plane, thereby ensuring that all traffic is auditable. The control plane does not specify egress rules, which allows outbound traffic by default, while allowing you to enforce a more specific network policy if you wish.
-[Container Network Interface (CNI)](https://github.com/containernetworking/cni#what-is-cni)
-plugins to implement network segmentation and tenant isolation in the Kubernetes
-cluster. This enforces network boundaries between pods, preventing users from
+Coder uses
+[Kubernetes NetworkPolicies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+to enforce network segmentation and tenant isolation within your cluster.
+
+Coder's network isolation policy blocks all ingress traffic to workspaces except
+traffic from the control plane (this ensures that you can audit all traffic).
+However, the control plane does not specify egress rules; by default, it allows
+outbound traffic. However, you can still enforce a more specific network policy.
+
+[Container network interface (CNI)](https://github.com/containernetworking/cni#what-is-cni)
+plugins implement network segmentation and tenant isolation in the Kubernetes
+cluster. They enforce network boundaries between pods, preventing users from
 accessing other workspaces.
 
-If your Container Network Interface (CNI) plugin does not support NetworkPolicy enforcement, traffic between workspaces and other containerized workloads within the same cluster will be permitted to communicate without restriction. Consider testing your container networking after installation to ensure that the behavior is as you expect.
-be able to communicate with each other without restriction.
+If your container network interface (CNI) plugin does not support NetworkPolicy
+enforcement, traffic between workspaces, and other containerized workloads
+within the same cluster will be permitted to communicate without restriction.
+Consider testing your container networking _after_ installing Coder to ensure
+that the behavior is as expected.
 
-See more:
-[Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+> If you're not sure which CNI plugin, we suggest
+> [Calico](https://docs.projectcalico.org/getting-started/kubernetes/quickstart).
 
 ## Licenses
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -43,11 +43,13 @@ currently require the following versions _or newer_:
 If you're using [Remote IDEs](../environments/editors.md), allow pop-ups; Coder
 launches the Remote IDE in a pop-up window.
 
-## Container Network Interface (CNI)
+## Network Policies
 
-Coder uses CNI plugins to implement network segmentation and tenant isolation.
-This enforces network boundaries between pods in the Kubernetes cluster,
-preventing users from accessing other workspaces.
+Coder uses
+[Container Network Interface (CNI)](https://github.com/containernetworking/cni#what-is-cni)
+plugins to implement network segmentation and tenant isolation in the Kubernetes
+cluster. This enforces network boundaries between pods, preventing users from
+accessing other workspaces.
 
 If there is no CNI plugin configured to enforce such policies, workspaces will
 be able to communicate with each other without restriction.

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -43,6 +43,17 @@ currently require the following versions _or newer_:
 If you're using [Remote IDEs](../environments/editors.md), allow pop-ups; Coder
 launches the Remote IDE in a pop-up window.
 
+## Container Network Interface (CNI)
+
+Coder uses CNI plugins to implement network segmentation and tenant isolation.
+This enforces network boundaries between pods in the Kubernetes cluster, preventing
+users from accessing other workspaces.
+
+If there is no CNI plugin configured to enforce such policies, workspaces will be
+able to communicate with each other without restriction.
+
+See more: [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+
 ## Licenses
 
 The use of Coder deployments requires a license that's emailed to you.

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -46,13 +46,14 @@ launches the Remote IDE in a pop-up window.
 ## Container Network Interface (CNI)
 
 Coder uses CNI plugins to implement network segmentation and tenant isolation.
-This enforces network boundaries between pods in the Kubernetes cluster, preventing
-users from accessing other workspaces.
+This enforces network boundaries between pods in the Kubernetes cluster,
+preventing users from accessing other workspaces.
 
-If there is no CNI plugin configured to enforce such policies, workspaces will be
-able to communicate with each other without restriction.
+If there is no CNI plugin configured to enforce such policies, workspaces will
+be able to communicate with each other without restriction.
 
-See more: [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+See more:
+[Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
 
 ## Licenses
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -45,13 +45,13 @@ launches the Remote IDE in a pop-up window.
 
 ## Network Policies
 
-Coder uses
+Coder uses [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) to enforce network segmentation and tenant isolation within your cluster. Coder's network isolation policy blocks all ingress traffic to workspaces, with the exception of traffic from the control plane, thereby ensuring that all traffic is auditable. The control plane does not specify egress rules, which allows outbound traffic by default, while allowing you to enforce a more specific network policy if you wish.
 [Container Network Interface (CNI)](https://github.com/containernetworking/cni#what-is-cni)
 plugins to implement network segmentation and tenant isolation in the Kubernetes
 cluster. This enforces network boundaries between pods, preventing users from
 accessing other workspaces.
 
-If there is no CNI plugin configured to enforce such policies, workspaces will
+If your Container Network Interface (CNI) plugin does not support NetworkPolicy enforcement, traffic between workspaces and other containerized workloads within the same cluster will be permitted to communicate without restriction. Consider testing your container networking after installation to ensure that the behavior is as you expect.
 be able to communicate with each other without restriction.
 
 See more:


### PR DESCRIPTION
Adding CNI requirement to Setup > Requirements, as customers have deployed Coder without network policies enforced, leading to surprises about security holes in their clusters.

Open to edits & feedback.

[Clubhouse story](https://app.clubhouse.io/coder/story/9751/document-network-policy-requirement)