### PR TITLE
fix: Remove non-existent file from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -321,9 +321,6 @@
       "path": "./changelog/index.md",
       "children": [
         {
-          "path": "./changelog/1.17.3.md"
-        },
-        {
           "path": "./changelog/1.17.2.md"
         },
         {


### PR DESCRIPTION
I made a smol mistake when testing and merging #208 - I had used the scripts to create a fake changelog for 1.17.3, but forgot to erase the entry from `manifest.json`