### PR TITLE
update GCP node type in create cluster command

### DIFF
--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -24,7 +24,7 @@ clusters create "$NEW_CLUSTER_NAME" \
    --zone "$ZONE" \
    --no-enable-basic-auth \
    --cluster-version "latest" \
-   --machine-type "n1-standard-4" \
+   --machine-type "n1-highmem-4" \
    --image-type "COS" \
    --disk-type "pd-standard" \
    --disk-size "50" \

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -60,7 +60,7 @@ gcloud beta container --project "$PROJECT_ID" \
     --no-enable-basic-auth \
     --node-version "latest" \
     --cluster-version "latest" \
-    --machine-type "n1-standard-2" \
+    --machine-type "n1-highmem-4" \
     --image-type "UBUNTU" \
     --disk-type "pd-standard" \
     --disk-size "50" \


### PR DESCRIPTION
updating node type to `n1-highmem-4` as it better supports the use of CVMs and removes scale up issues during env builds. uses the same amount of vCPUs as the prior `n1-standard-4` just with added memory. 

we've seen customers deploy via our happy path and realize they need a bigger node after the fact. hopefully this will avoid that issue. 