### PR TITLE
chore: Pin to node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",
-    "@types/node": "^14.14.36",
+    "@types/node": "^12.20.7",
     "@types/semver-compare": "^1.0.1",
     "all-contributors-cli": "^6.20.0",
     "husky": "^6.0.0",
@@ -19,6 +19,9 @@
     "semver-compare": "^1.0.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"
+  },
+  "engines": {
+    "node": "^12.16.0"
   },
   "lint-staged": {
     "*.{css,html,js,json,jsx,ts,tsx,yaml,yml}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,10 +35,10 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/node@^14.14.36":
-  version "14.14.36"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.36.tgz#5637905dbb15c30a33a3c65b9ef7c20e3c85ebad"
-  integrity sha512-kjivUwDJfIjngzbhooRnOLhGYz6oRFi+L+EpMjxroDYXwDw9lHrJJ43E+dJ6KAd3V3WxWAJ/qZE9XKYHhjPOFQ==
+"@types/node@^12.20.7":
+  version "12.20.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
+  integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Context:

In #233 it was observed that we allow @types/node in LTS 14, but that
due to operational/architectural issues of cdr/docs and cdr/m, we should
instead consistently use version 12 of node.

Details:

- Set engines.node version to "^12.16.0". This is equivalent to the
  version used in cdr/m. Note that in npm, the caret means that the
latest minor and patch versions are OK - meaning 12.21.x is compatible
with ^12.16.0
- Use the latest version of @types/node, with a caret to indicate minor
  and patch versions are compatible

Resolves: #244