### PR TITLE
chore: Add release pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release-template.md
@@ -1,0 +1,14 @@
+## Changelog Run History (`cdr/m/scripts/clog/generate-clog.sh`)
+
+- **yyyy-mm-dd**
+  - Using Previous Object: `<some-ref>`
+  - Using Latest Object: `<some-ref>`
+
+## Release Checklist
+
+- [ ] All Feature documentation merged
+- [ ] Changelog completed
+- [ ] Technical Engineer Review
+- [ ] Documentation Owner Review
+- [ ] Release Manager Review
+- [ ] Commit cleaned up and co-authored

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,1 +1,2 @@
+.github/PULL_REQUEST_TEMPLATE/release-template.md
 node_modules


### PR DESCRIPTION
Theoretically, this PR template should only apply if using the query param `?template=release-template.md` - at least from what I gather when reading https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository

I want to ensure normal PRs don't have this information autofilled, but alas I'm unsure how to proceed without actually merging it first