### PR TITLE
chore: Print PR template link in create-clog.sh

### DIFF
--- a/scripts/create-clog.sh
+++ b/scripts/create-clog.sh
@@ -101,9 +101,12 @@ function update_manifest () {
 
 function print_pr_info () {
   branch="$(git branch --show-current)"
-  echo "TIP: After comitting this branch visit"
+  echo
+  echo "tip: After comitting this branch visit"
+  echo
   echo "https://github.com/cdr/docs/compare/master...${branch}?template=release-template.md"
-  echo "to open a PR using the Release Template"
+  echo
+  echo "to open a PR using the release PR template"
 }
 
 # main program

--- a/scripts/create-clog.sh
+++ b/scripts/create-clog.sh
@@ -101,11 +101,8 @@ function update_manifest () {
 
 function print_pr_info () {
   branch="$(git branch --show-current)"
-  echo
   echo "tip: After comitting this branch visit"
-  echo
   echo "https://github.com/cdr/docs/compare/master...${branch}?template=release-template.md"
-  echo
   echo "to open a PR using the release PR template"
 }
 

--- a/scripts/create-clog.sh
+++ b/scripts/create-clog.sh
@@ -99,8 +99,16 @@ function update_manifest () {
   popd > /dev/null
 }
 
+function print_pr_info () {
+  branch="$(git branch --show-current)"
+  echo "TIP: After comitting this branch visit"
+  echo "https://github.com/cdr/docs/compare/master...${branch}?template=release-template.md"
+  echo "to open a PR using the Release Template"
+}
+
 # main program
 init "$@"
 create_from_template
 update_manifest
+print_pr_info
 echo "Done"

--- a/scripts/create-clog.sh
+++ b/scripts/create-clog.sh
@@ -101,7 +101,7 @@ function update_manifest () {
 
 function print_pr_info () {
   branch="$(git branch --show-current)"
-  echo "tip: After comitting this branch visit"
+  echo "tip: After committing this branch visit"
   echo "https://github.com/cdr/docs/compare/master...${branch}?template=release-template.md&expand=1"
   echo "to open a PR using the release PR template"
 }


### PR DESCRIPTION
![Screenshot from 2021-04-07 21-42-44](https://user-images.githubusercontent.com/11184711/113961539-d7e2b600-97eb-11eb-8178-b59ca65c4264.png)
![Screenshot from 2021-04-07 21-42-35](https://user-images.githubusercontent.com/11184711/113961543-d87b4c80-97eb-11eb-9d62-6c2d82743945.png)

---

```console
$ ./scripts/create-clog.sh --version=1.19.0 --release-date=$(date +%D)
Creating template using version: 1.19.0 and release date: 04/08/21
Calling add_clog_to_manifest.ts to update manifest.json
appending manifest.json with clog version:  1.19.0
Done
tip: run yarn fmt:fix to prettify manifest.json
tip: After comitting this branch visit
https://github.com/cdr/docs/compare/master...vapurrmaid/test-pr-template?template=release-template.md&expand=1
to open a PR using the release PR template
Done
```