### PR TITLE
clarify timescale deletion

### DIFF
--- a/setup/updating.md
+++ b/setup/updating.md
@@ -105,7 +105,8 @@ If this happens, we recommend uninstalling and reinstalling:
    environments or their associated volumes.
 
    > `helm uninstall` will delete the timescale instance internal to the
-   > cluster. If you're using an external PostgreSQL database, this will not be
+   > cluster, but will not delete its associated volume, so all data will remain
+   > intact. If you're using an external PostgreSQL database, this will not be
    > affected.
 
    ```console

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -105,7 +105,7 @@ If this happens, we recommend uninstalling and reinstalling:
    environments or their associated volumes.
 
    > `helm uninstall` will delete the timescale instance internal to the
-   > cluster, but will not delete its associated volume, so all data will remain
+   > cluster but *not* its associated volume, so all data will remain
    > intact. If you're using an external PostgreSQL database, this will not be
    > affected.
 


### PR DESCRIPTION
adding the following clarification:

`helm uninstall` will delete the timescale _instance_ that is internal to the cluster which Coder is deployed on, but the associated timescale _volume_ will remain intact.

this means any subsequent `helm install` will create a new timescale instance with the same data as the previous, due to the volume remaining intact.

please wordsmith as needed. thank you!