### PR TITLE
add link to README with helm values

### DIFF
--- a/setup/installation.md
+++ b/setup/installation.md
@@ -62,6 +62,8 @@ kubectl config set-context --current --namespace=coder
    you are _not_ modifying, otherwise the contents of `values.yaml` will
    override those in the default chart.
 
+   > [View the configuration options available in the `values.yaml` file here](https://github.com/cdr/enterprise-helm#coder-helm)
+
    c. Upgrade/install your Coder deployment with the updated helm chart (be sure
    to replace the placeholder value with your Coder version):
    `helm upgrade coder coder/coder -n coder --version=<VERSION> -f values.yaml`.

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -62,7 +62,7 @@ kubectl config set-context --current --namespace=coder
    you are _not_ modifying, otherwise the contents of `values.yaml` will
    override those in the default chart.
 
-   > [View the configuration options available in the `values.yaml` file here](https://github.com/cdr/enterprise-helm#coder-helm)
+   > View the [configuration options available in the `values.yaml` file.](https://github.com/cdr/enterprise-helm#values)
 
    c. Upgrade/install your Coder deployment with the updated helm chart (be sure
    to replace the placeholder value with your Coder version):


### PR DESCRIPTION
adding link to the helm values `README` file in the installation section. right now, we basically say "edit the `values.yaml` file as needed" - without any context as to the configuration options available to users. ideally this will point users in the right direction, and give them a better understanding as to which values are relevant for their deployment needs.