### PR TITLE
specify ECDSA use

### DIFF
--- a/admin/git.md
+++ b/admin/git.md
@@ -20,11 +20,13 @@ Coder integrates with the following service providers for authentication and
   rel="noreferrer noopener">doesn't support</a> managing SSH keys for users via
   OAuth)
 
-Note that linking your Coder account with a git service provider is _not_
-required. Instead, you can use Visual Studio Code with git, the command-line
-tool, and we expect that this combination will work with most hosting software
-or services. However, Coder doesn't test these and cannot provide
-recommendations or support.
+Linking your Coder account with a git service provider is _not_ required.
+Instead, you can use Visual Studio Code with git, the command-line tool, and we
+expect that this combination will work with most hosting software or services.
+However, Coder doesn't test these and cannot provide recommendations or support.
+
+**Note** The public key provided by Coder uses the `ECDSA` key algorithm. Ensure
+this is supported by your git provider.
 
 ![Configure Git Integration](../assets/git-admin.png)
 

--- a/admin/git.md
+++ b/admin/git.md
@@ -25,7 +25,7 @@ Instead, you can use Visual Studio Code with git, the command-line tool, and we
 expect that this combination will work with most hosting software or services.
 However, Coder doesn't test these and cannot provide recommendations or support.
 
-**Note** The public key provided by Coder uses the `ECDSA` key algorithm. Ensure
+**Note** The public key provided by Coder uses the ECDSA key algorithm. Ensure
 this is supported by your git provider.
 
 ![Configure Git Integration](../assets/git-admin.png)

--- a/environments/preferences.md
+++ b/environments/preferences.md
@@ -36,12 +36,12 @@ private key that Coder inserts automatically into your environments. The public
 key is useful for services, such as Git, Bitbucket, GitHub, and GitLab, that you
 need to access from your environment.
 
-Note that the SSH public key uses the ECDSA key algorithm rather than more
-commonly used RSA key. This provides you with a smaller, more performant key for
-the same level of security as RSA.
-
 If necessary, you can regenerate your key. Be sure to provide your updated key
 to all of the services you use. Otherwise, they won't work.
+
+> The SSH public key uses the ECDSA key algorithm instead of the more commonly
+> used RSA key. This provides you with a smaller, more performant key with the
+> same level of security as RSA.
 
 ## Linked accounts
 

--- a/environments/preferences.md
+++ b/environments/preferences.md
@@ -36,6 +36,10 @@ private key that Coder inserts automatically into your environments. The public
 key is useful for services, such as Git, Bitbucket, GitHub, and GitLab, that you
 need to access from your environment.
 
+Note that the SSH public key uses the ECDSA key algorithm rather than more
+commonly used RSA key. This provides you with a smaller, more performant key for
+the same level of security as RSA.
+
 If necessary, you can regenerate your key. Be sure to provide your updated key
 to all of the services you use. Otherwise, they won't work.
 


### PR DESCRIPTION
adding context around our SSH keys. they're generated using the ECDSA algorithm, which is different than the commonly used RSA. this can affect which git providers customers use.