### PR TITLE
potential fix to workspace provider upgrade command

### DIFF
--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -158,8 +158,7 @@ values changes; you can do this with
 helm upgrade coder-workspace-provider coder/workspace-provider \
     --version=[CODER_VERSION] \
     --atomic \
-    --install \
-    --force
+    --install
 ```
 
 If you want to update any of the helm chart's values, you can do so by supplying

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -1,24 +1,23 @@
 ---
-title: Environment variables
-description:
-  Learn how to work with CODER_* environment variables inside workspaces
+title: Workspace variables
+description: Learn how to work with CODER_* workspace variables
 ---
 
-Coder injects a standard set of environment variables that allow you to access
+Coder injects a standard set of workspace variables that allow you to access
 contextual information about your workspace.
 
-To obtain a list of environment variables and their values, launch the
+To obtain a list of workspace variables and their values, launch the
 **Terminal** via the Coder Dashboard and run:
 
 ```console
 env | grep CODER_
 ```
 
-## Available environment variables
+## Available workspace variables
 
 <table>
     <tr>
-        <th>Environment variable</th>
+        <th>Workspace variable</th>
         <th>Description</th>
     </tr>
     <tr>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -1,23 +1,24 @@
 ---
-title: Workspace variables
-description: Learn how to work with CODER_* workspace variables
+title: Environment variables
+description:
+  Learn how to work with CODER_* environment variables inside workspaces
 ---
 
-Coder injects a standard set of workspace variables that allow you to access
+Coder injects a standard set of environment variables that allow you to access
 contextual information about your workspace.
 
-To obtain a list of workspace variables and their values, launch the
+To obtain a list of environment variables and their values, launch the
 **Terminal** via the Coder Dashboard and run:
 
 ```console
 env | grep CODER_
 ```
 
-## Available workspace variables
+## Available environment variables
 
 <table>
     <tr>
-        <th>Workspace variable</th>
+        <th>Environment variable</th>
         <th>Description</th>
     </tr>
     <tr>


### PR DESCRIPTION
Context: I remember we removed `--force` from our standard update as it was constantly failing the update as described here: https://coder.com/docs/setup/updating#fixing-a-failed-upgrade: https://github.com/cdr/docs/pull/171

When updating my workspace provider, I ran into similar errors and my deployment succeeded without the command. I'm not exactly sure why, but I believe remember seeing `--force` only leads to a successful install on specific versions of helm. A sanity check would help, though.