### PR TITLE
state yaml syntax case-sensitivity

### DIFF
--- a/workspaces/workspaces-as-code/templates.md
+++ b/workspaces/workspaces-as-code/templates.md
@@ -22,6 +22,8 @@ The following is a sample workspace template that makes use of all available
 fields. Depending on your use case, you may not need all of the options
 available.
 
+> Note that the fields are **case-sensitive**.
+
 For detailed information on the fields available, see the
 [subsequent sections](#workspace-template-fields) of this article
 


### PR DESCRIPTION
the template fields in the WaC yaml file are case-sensitive, and won't populate correctly if case syntax is incorrect.

[related clubhouse story ch11430](https://app.clubhouse.io/coder/story/11430/update-wac-docs-stating-yaml-syntax-is-case-sensitive)