### PR TITLE
update wp commands with namespace

### DIFF
--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -156,6 +156,7 @@ values changes; you can do this with
 
 ```bash
 helm upgrade coder-workspace-provider coder/workspace-provider \
+    --namespace=[your-wp-namespace]
     --version=[CODER_VERSION] \
     --atomic \
     --install \

--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -52,7 +52,7 @@ We recommend running workspace providers in a separate
 to do so, run:
 
 ```bash
-kubectl create namespace [your-wp-namespace]
+kubectl create namespace [YOUR_WORKSPACE_PROVIDER_NAMESPACE]
 ```
 
 Next, change the kubectl context to point to your newly created namespace:
@@ -103,7 +103,7 @@ when communicating with the Coder deployment.
 
    ```bash
    helm upgrade coder-workspace-provider coder/workspace-provider \
-      --namespace=[your-wp-namespace]
+      --namespace=[YOUR_WORKSPACE_PROVIDER_NAMESPACE]
       --version=[CODER_VERSION] \
       --atomic \
       --install \
@@ -157,7 +157,7 @@ values changes; you can do this with
 
 ```bash
 helm upgrade coder-workspace-provider coder/workspace-provider \
-    --namespace=[your-wp-namespace]
+    --namespace=[YOUR_WORKSPACE_PROVIDER_NAMESPACE]
     --version=[CODER_VERSION] \
     --atomic \
     --install \

--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -52,7 +52,7 @@ We recommend running workspace providers in a separate
 to do so, run:
 
 ```bash
-kubectl create namespace coder
+kubectl create namespace [your-wp-namespace]
 ```
 
 Next, change the kubectl context to point to your newly created namespace:
@@ -103,6 +103,7 @@ when communicating with the Coder deployment.
 
    ```bash
    helm upgrade coder-workspace-provider coder/workspace-provider \
+      --namespace=[your-wp-namespace]
       --version=[CODER_VERSION] \
       --atomic \
       --install \


### PR DESCRIPTION
adding the `--namespace` flag to the various workspace provider-related commands, as it can spell trouble for those who run these commands in the wrong namespace. open to thoughts, feedback.

related clubhouse story [ch11641](https://app.clubhouse.io/coder/story/11641/workspace-provider-namespace-called-coder-in-docs-creates-confusion-add-namespace-to-helm-upgrade)