### PR TITLE
remove optional flag & make commands consistent

### DIFF
--- a/guides/admin/helm-charts.md
+++ b/guides/admin/helm-charts.md
@@ -29,7 +29,7 @@ Coder's Helm chart.
    version):
 
    ```console
-   helm upgrade coder coder/coder -n coder --version=<VERSION> -f current-values.yaml
+   helm upgrade coder coder/coder -n coder --version=<VERSION> --values current-values.yaml
    ```
 
    **Note:** You must complete this step every time you update the Helm chart

--- a/guides/admin/helm-charts.md
+++ b/guides/admin/helm-charts.md
@@ -4,33 +4,33 @@ description: Learn how to modify configuration values in Helm charts.
 ---
 
 This article will show you how to modify the default configuration values in
-Coder's helm chart.
+Coder's Helm chart.
 
-> You can
-> [see the contents of Coder's helm chart](https://github.com/cdr/enterprise-helm/blob/master/values.yaml)
-> on GitHub.
+> You can [see the contents of Coder's Helm
+> chart](https://github.com/cdr/enterprise-helm/blob/master/values.yaml) on
+> GitHub.
 
-1. Get a copy of your existing helm chart and save it as `values.yaml`
+1. Get a copy of your existing Helm chart and save it as `current-values.yaml`
 
    ```console
-   helm show values coder/coder > values.yaml
+   helm show values coder/coder > current-values.yaml
    ```
 
-1. Open the `values.yaml` file using the text editor of your choice
+1. Open the `current-values.yaml` file using the text editor of your choice
 
-1. Edit the `values.yaml` file as needed. **Be sure to remove the lines that you
-   are _not_ modifying. Otherwise, the contents of `values.yaml` will override
-   those in the default chart**
+1. Edit the `current-values.yaml` file as needed. **Be sure to remove the lines
+   that you are _not_ modifying. Otherwise, the contents of
+   `current-values.yaml` will override those in the default chart**
 
-1. Save the `values.yaml` file
+1. Save the `current-values.yaml` file
 
-1. Update your Coder deployment with your new helm chart values. Be sure to
+1. Update your Coder deployment with your new Helm chart values. Be sure to
    replace the placeholder value in the following command with your Coder
    version):
 
    ```console
-   helm upgrade coder coder/coder -n coder --version=<VERSION> -f values.yaml
+   helm upgrade coder coder/coder -n coder --version=<VERSION> -f current-values.yaml
    ```
 
-   **Note:** You must complete this step every time you update the helm chart
+   **Note:** You must complete this step every time you update the Helm chart
    values

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -55,20 +55,25 @@ kubectl config set-context --current --namespace=coder
    modify the helm chart to update your PostgreSQL databases (step 4) and enable
    dev URLs (step 5):
 
-   a. Get a copy of your existing helm chart and save it as `values.yaml`:
-   `helm show values coder/coder > values.yaml`
+   a. Get a copy of your existing helm chart and save it as `current-values.yaml`:
+   `helm show values coder/coder > current-values.yaml`
 
-   b. Edit the `values.yaml` file as needed. Be sure to remove the lines that
-   you are _not_ modifying, otherwise the contents of `values.yaml` will
-   override those in the default chart.
+   b. Edit the `current-values.yaml` file as needed. Be sure to remove the lines
+   that you are _not_ modifying, otherwise the contents of `current-values.yaml`
+   will override those in the default chart.
 
    > View the
    > [configuration options available in the `values.yaml` file.](https://github.com/cdr/enterprise-helm#values)
 
    c. Upgrade/install your Coder deployment with the updated helm chart (be sure
-   to replace the placeholder value with your Coder version):
-   `helm upgrade coder coder/coder -n coder --version=<VERSION> -f values.yaml`.
-   **This must be done whenever you update the helm chart.**
+   to replace the placeholder value with your Coder version). **This must be done
+   whenever you update the helm chart:**
+
+   ```console
+   helm upgrade coder coder/coder -n coder --version=<VERSION> --values current-values.yaml`
+   ```
+
+   _Note: If you omit `--version`, you'll upgrade to the latest version._
 
 1. Ensure that you have superuser privileges to your PostgreSQL database. Add
    the following to your helm chart so that Coder uses your external PostgreSQL

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -70,7 +70,7 @@ kubectl config set-context --current --namespace=coder
    whenever you update the Helm chart:**
 
    ```console
-   helm upgrade coder coder/coder -n coder --version=<VERSION> --values current-values.yaml`
+   helm upgrade coder coder/coder -n coder --version=<VERSION> --values current-values.yaml
    ```
 
    _Note: If you omit `--version`, you'll upgrade to the latest version._

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -11,7 +11,7 @@ This article walks you through the process of installing Coder onto your
 Install the following dependencies if you haven't already:
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- [helm](https://helm.sh/docs/intro/install/)
+- [Helm](https://helm.sh/docs/intro/install/)
 
 **For production deployments:** set up and use an external
 [PostgreSQL](https://www.postgresql.org/docs/12/admin.html) instance to store
@@ -35,13 +35,13 @@ kubectl config set-context --current --namespace=coder
 
 ## Installing Coder
 
-1. Add the Coder helm repo
+1. Add the Coder Helm repo
 
    ```console
    helm repo add coder https://helm.coder.com
    ```
 
-1. Install the helm chart onto your cluster (see the
+1. Install the Helm chart onto your cluster (see the
    [changelog](../changelog/index.md) for a list of Coder versions or run
    `helm search repo coder -l`)
 
@@ -51,11 +51,11 @@ kubectl config set-context --current --namespace=coder
 
    **Steps 3-5 are optional for non-production deployments.**
 
-1. Get a copy of your helm chart so that you can modify it; you'll need to
-   modify the helm chart to update your PostgreSQL databases (step 4) and enable
+1. Get a copy of your Helm chart so that you can modify it; you'll need to
+   modify the Helm chart to update your PostgreSQL databases (step 4) and enable
    dev URLs (step 5):
 
-   a. Get a copy of your existing helm chart and save it as `current-values.yaml`:
+   a. Get a copy of your existing Helm chart and save it as `current-values.yaml`:
    `helm show values coder/coder > current-values.yaml`
 
    b. Edit the `current-values.yaml` file as needed. Be sure to remove the lines
@@ -65,9 +65,9 @@ kubectl config set-context --current --namespace=coder
    > View the
    > [configuration options available in the `values.yaml` file.](https://github.com/cdr/enterprise-helm#values)
 
-   c. Upgrade/install your Coder deployment with the updated helm chart (be sure
+   c. Upgrade/install your Coder deployment with the updated Helm chart (be sure
    to replace the placeholder value with your Coder version). **This must be done
-   whenever you update the helm chart:**
+   whenever you update the Helm chart:**
 
    ```console
    helm upgrade coder coder/coder -n coder --version=<VERSION> --values current-values.yaml`
@@ -76,7 +76,7 @@ kubectl config set-context --current --namespace=coder
    _Note: If you omit `--version`, you'll upgrade to the latest version._
 
 1. Ensure that you have superuser privileges to your PostgreSQL database. Add
-   the following to your helm chart so that Coder uses your external PostgreSQL
+   the following to your Helm chart so that Coder uses your external PostgreSQL
    databases:
 
    ```yaml
@@ -99,7 +99,7 @@ kubectl config set-context --current --namespace=coder
 
 1. [Enable dev URL usage](../admin/devurls.md). Dev URLs allow users to access
    the web servers running in your workspace. To enable, provide a wildcard
-   domain and its DNS certificate and update your helm chart accordingly. This
+   domain and its DNS certificate and update your Helm chart accordingly. This
    step is **optional** but recommended.
 
 1. After you've created the pod, tail the logs to find the randomly generated

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -7,11 +7,11 @@ This guide will show you how to update your Coder deployment.
 
 ## Prerequisites
 
-- If you haven't already, install [helm](https://helm.sh/docs/intro/install/).
+- If you haven't already, install [Helm](https://helm.sh/docs/intro/install/).
 
-- Before beginning the update process, ensure that you've added the Coder helm
+- Before beginning the update process, ensure that you've added the Coder Helm
   repo to your cluster. You can verify that the Coder repo has been added to
-  helm using `helm repo list`:
+  Helm using `helm repo list`:
 
   ```console
   $ helm repo list
@@ -48,7 +48,7 @@ To update Coder, follow these steps:
    helm repo update
    ```
 
-1. Export your current helm chart values into a file:
+1. Export your current Helm chart values into a file:
 
    ```console
    helm get values --namespace coder coder > current-values.yaml
@@ -57,7 +57,7 @@ To update Coder, follow these steps:
    > Make sure that your values only contain the changes you want (i.e., if you
    > see references to a prior version, you may need to remove these).
 
-1. Provide your helm chart values file and upgrade to the desired version (e.g.,
+1. Provide your Helm chart values file and upgrade to the desired version (e.g.,
    1.16.1):
 
    _Note: If you omit `--version`, you'll upgrade to the latest version._
@@ -70,7 +70,7 @@ To update Coder, follow these steps:
 ## Fixing a failed upgrade
 
 While upgrading, the process may fail. You'll see an error message similar to
-the following samples indicating that a field is immutable or that helm doesn't
+the following samples indicating that a field is immutable or that Helm doesn't
 control a resource:
 
 ```text
@@ -92,7 +92,7 @@ be set to "coder"; annotation validation error: missing key
 
 If this happens, we recommend uninstalling and reinstalling:
 
-1. Export the helm chart values into a file:
+1. Export the Helm chart values into a file:
 
    ```console
    helm get values --namespace coder coder > current-values.yaml
@@ -122,7 +122,7 @@ If this happens, we recommend uninstalling and reinstalling:
    public IP address or hostname after you reinstall; if this is the case,
    update your DNS provider with your new IP and CNAME.
 
-1. Run the `upgrade` command with the new version number and helm chart values
+1. Run the `upgrade` command with the new version number and Helm chart values
    file:
 
    ```console

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -48,10 +48,10 @@ To update Coder, follow these steps:
    helm repo update
    ```
 
-1. (Optional) Export the current helm chart values into a file:
+1. Export your current helm chart values into a file:
 
    ```console
-   helm get values --namespace coder coder > current-values.yml
+   helm get values --namespace coder coder > current-values.yaml
    ```
 
    > Make sure that your values only contain the changes you want (i.e., if you
@@ -64,7 +64,7 @@ To update Coder, follow these steps:
 
    ```console
    helm upgrade --namespace coder --install --atomic --wait \
-     --version 1.16.1 coder coder/coder --values current-values.yml
+     --version 1.16.1 coder coder/coder --values current-values.yaml
    ```
 
 ## Fixing a failed upgrade
@@ -95,7 +95,7 @@ If this happens, we recommend uninstalling and reinstalling:
 1. Export the helm chart values into a file:
 
    ```console
-   helm get values --namespace coder coder > current-values.yml
+   helm get values --namespace coder coder > current-values.yaml
    ```
 
    > Double-check your values file to ensure it only contains your changes.
@@ -128,7 +128,7 @@ If this happens, we recommend uninstalling and reinstalling:
    ```console
    helm upgrade --namespace coder --atomic \
    --wait --install --version 1.16.1 \
-   coder coder/coder --values current-values.yml
+   coder coder/coder --values current-values.yaml
    ```
 
    The ingress may attach to a new public IP address; if this happens, you must


### PR DESCRIPTION
removing "optional" from the `helm get values` command, as saving the current `values.yaml` file is quite important for retaining a Coder configuration across upgrades and troubleshooting any upgrade-related errors.

additionally, there were some inconsistencies with the upgrade commands & use of custom `values.yaml` files, so I cleaned those up.