### PR TITLE
add links to cert-manager troubleshooting

### DIFF
--- a/guides/ssl-certificates/cloudDNS.md
+++ b/guides/ssl-certificates/cloudDNS.md
@@ -217,8 +217,8 @@ At this point, you can return to **step 6** of the
 [installation](../../setup/installation.md) guide to obtain the admin
 credentials you need to log in.
 
----
+## Troubleshooting
 
 If you are not getting a valid certificate after redeploying, see
-[this troubleshooting guide](https://cert-manager.io/docs/faq/acme/) by
-cert-manager.
+[cert-manager's troubleshooting guide](https://cert-manager.io/docs/faq/acme/)
+for additional assistance.

--- a/guides/ssl-certificates/cloudDNS.md
+++ b/guides/ssl-certificates/cloudDNS.md
@@ -216,3 +216,9 @@ There are additional steps to make sure that your hostname and Dev URLs work.
 At this point, you can return to **step 6** of the
 [installation](../../setup/installation.md) guide to obtain the admin
 credentials you need to log in.
+
+---
+
+If you are not getting a valid certificate after redeploying, see
+[this troubleshooting guide](https://cert-manager.io/docs/faq/acme/) by
+cert-manager.

--- a/guides/ssl-certificates/cloudflare.md
+++ b/guides/ssl-certificates/cloudflare.md
@@ -181,4 +181,7 @@ devurls:
   host: "*.coder.example.com"
 ```
 
-Be sure to redeploy Coder after altering your helm values.
+Be sure to redeploy Coder after altering your helm values. If you are still not
+getting a valid certificate, see
+[this troubleshooting guide](https://cert-manager.io/docs/faq/acme/) by
+cert-manager.

--- a/guides/ssl-certificates/cloudflare.md
+++ b/guides/ssl-certificates/cloudflare.md
@@ -181,7 +181,7 @@ devurls:
   host: "*.coder.example.com"
 ```
 
-Be sure to redeploy Coder after altering your helm values. If you are still not
-getting a valid certificate, see
-[this troubleshooting guide](https://cert-manager.io/docs/faq/acme/) by
-cert-manager.
+Be sure to redeploy Coder after changing your Helm values. If, after
+redeploying, you're not getting a valid certificate, see [cert-manager's
+troubleshooting guide](https://cert-manager.io/docs/faq/acme/) for additional
+assistance.

--- a/guides/ssl-certificates/route53.md
+++ b/guides/ssl-certificates/route53.md
@@ -171,6 +171,5 @@ URLs work.
 At this point, you can return to **step 6** of the
 [installation](../../setup/installation.md) guide to obtain the admin
 credentials you need to log in. If you are not getting a valid certificate after
-redeploying, see
-[this troubleshooting guide](https://cert-manager.io/docs/faq/acme/) by
-cert-manager.
+redeploying, see [cert-manager's troubleshooting
+guide](https://cert-manager.io/docs/faq/acme/) for additional assistance.

--- a/guides/ssl-certificates/route53.md
+++ b/guides/ssl-certificates/route53.md
@@ -170,4 +170,7 @@ URLs work.
 
 At this point, you can return to **step 6** of the
 [installation](../../setup/installation.md) guide to obtain the admin
-credentials you need to log in.
+credentials you need to log in. If you are not getting a valid certificate after
+redeploying, see
+[this troubleshooting guide](https://cert-manager.io/docs/faq/acme/) by
+cert-manager.


### PR DESCRIPTION
I often refer to this troubleshooting guide to see where certificate requests go wrong (e.x invalid API key, incorrect formatting, bad secret name, no annotation added). 