### PR TITLE
update: WaC template version & file naming

### DIFF
--- a/workspaces/workspaces-as-code/index.md
+++ b/workspaces/workspaces-as-code/index.md
@@ -9,14 +9,15 @@ workspaces. WAC allows you to define and create new workspaces using **workspace
 templates**.
 
 [Workspace templates](./templates.md) are declarative YAML files that describe
-how to configure workspaces and their supporting infrastructure.
+how to configure workspaces and their supporting infrastructure. Both `.yaml` and
+`.yml` extensions are supported.
 
 ## Requirements
 
 - You must configure a [Git OAuth service of your choice](../../admin/git.md)
 - The image you use in your template **must** have been
   [imported](../../images/importing.md) into Coder
-- A `.coder/coder.yaml` file exists in your repository.
+- A `.coder/<template-name>.yaml` file exists in your repository.
 
 ## Creating a workspace template
 

--- a/workspaces/workspaces-as-code/index.md
+++ b/workspaces/workspaces-as-code/index.md
@@ -9,8 +9,8 @@ workspaces. WAC allows you to define and create new workspaces using **workspace
 templates**.
 
 [Workspace templates](./templates.md) are declarative YAML files that describe
-how to configure workspaces and their supporting infrastructure. Both `.yaml` and
-`.yml` extensions are supported.
+how to configure workspaces and their supporting infrastructure. Coder supports
+files with either the `.yaml` or `.yml` extension.
 
 ## Requirements
 

--- a/workspaces/workspaces-as-code/templates.md
+++ b/workspaces/workspaces-as-code/templates.md
@@ -11,7 +11,7 @@ Workspace templates are written as YAML and have a `.yaml` or `.yml` extension.
 Coder looks for your workspace template at the following path:
 
 ```text
-<repository-root>/.coder/coder.yaml
+<repository-root>/.coder/<template-name>.yaml
 ```
 
 ![Template Location](../../assets/wac-location.png)
@@ -28,7 +28,7 @@ For detailed information on the fields available, see the
 [subsequent sections](#workspace-template-fields) of this article
 
 ```yaml
-version: 0.1
+version: 0.2
 workspace:
   type: kubernetes
   spec:
@@ -76,7 +76,7 @@ workspace:
 
 ### version
 
-The version number of the config file being used. The current version is `0.1`.
+The version number of the config file being used. The current version is `0.2`.
 
 ### workspace
 


### PR DESCRIPTION
adding updates to WaC stuff:

- change template version to `0.2`
- clarify support for both `.yaml` & `.yml`
- replace `coder.yaml` with `<template-name.yaml>`