### PR TITLE
clarify local preview licensing

### DIFF
--- a/setup/kubernetes/local-preview.md
+++ b/setup/kubernetes/local-preview.md
@@ -8,7 +8,7 @@ set up a lightweight preview deployment, you can do so locally using using
 [Docker][docker-url] and [kind][kind-url].
 
 > Coder currently supports local preview only on workstations running macOS or
-> Linux.
+> Linux. A single-seat license will automatically be uploaded to Coder upon install.
 
 ## Prerequisites
 

--- a/setup/kubernetes/local-preview.md
+++ b/setup/kubernetes/local-preview.md
@@ -8,7 +8,9 @@ set up a lightweight preview deployment, you can do so locally using using
 [Docker][docker-url] and [kind][kind-url].
 
 > Coder currently supports local preview only on workstations running macOS or
-> Linux. A single-seat license will automatically be uploaded to Coder upon install.
+> Linux.
+
+Coder automatically uploads a single-seat license upon installation.
 
 ## Prerequisites
 


### PR DESCRIPTION
adding note that local preview automatically uploads a single-seat user license. will be helpful context for customers who unknowingly create additional users and run into the "license limit reached" screen.