### PR TITLE
Explain install.sh must be executable

### DIFF
--- a/workspaces/personalization.md
+++ b/workspaces/personalization.md
@@ -98,7 +98,9 @@ workspace or turn it on.
 
 At startup, Coder clones your dotfiles repository into `~/dotfiles`. If there's
 an executable `~/dotfiles/install.sh` present, Coder executes it. If not, all
-dot-prefixed files are symlinked to your home directory.
+dot-prefixed files are symlinked to your home directory.  
+
+You must mark the install.sh file as executable before committing it to your dotfiles repo.
 
 Read more about dotfiles repos [here](http://dotfiles.github.io/).
 

--- a/workspaces/personalization.md
+++ b/workspaces/personalization.md
@@ -100,7 +100,7 @@ At startup, Coder clones your dotfiles repository into `~/dotfiles`. If there's
 an executable `~/dotfiles/install.sh` present, Coder executes it. If not, all
 dot-prefixed files are symlinked to your home directory.  
 
-You must mark the install.sh file as executable before committing it to your dotfiles repo.
+- _Note: You must mark the `install.sh` file as executable before committing it to your dotfiles repo._
 
 Read more about dotfiles repos [here](http://dotfiles.github.io/).
 

--- a/workspaces/personalization.md
+++ b/workspaces/personalization.md
@@ -100,7 +100,8 @@ At startup, Coder clones your dotfiles repository into `~/dotfiles`. If there's
 an executable `~/dotfiles/install.sh` present, Coder executes it. If not, all
 dot-prefixed files are symlinked to your home directory.  
 
-- _Note: You must mark the `install.sh` file as executable before committing it to your dotfiles repo._
+> You **must** mark `install.sh` as executable before committing it to your
+> dotfiles repo.
 
 Read more about dotfiles repos [here](http://dotfiles.github.io/).
 


### PR DESCRIPTION
Add a sentence explaining that the install.sh must be marked executable and that coder won't do it for you.

I was assuming that coder would mark as executable anything it intended to execute.  That is not the case.