### PR TITLE
add one-liner for password reset

### DIFF
--- a/admin/access-control/password-reset.md
+++ b/admin/access-control/password-reset.md
@@ -37,7 +37,7 @@ kubectl get pods | grep cemanager- | awk '{print $1}' | head -n1
 # call the reset-admin-password subcommand
 kubectl exec -it <cemanager pod> -- cemanager reset-admin-password
 
-# or as a one-liner
+# alternatively, you can combine the two commands above into one line
 kubectl exec -it $(kubectl get pods | grep cemanager- | awk '{print $1}' | head -n1) -- cemanager reset-admin-password
 ```
 

--- a/admin/access-control/password-reset.md
+++ b/admin/access-control/password-reset.md
@@ -36,6 +36,9 @@ kubectl get pods | grep cemanager- | awk '{print $1}' | head -n1
 
 # call the reset-admin-password subcommand
 kubectl exec -it <cemanager pod> -- cemanager reset-admin-password
+
+# or as a one-liner
+kubectl exec -it $(kubectl get pods | grep cemanager- | awk '{print $1}' | head -n1) -- cemanager reset-admin-password
 ```
 
 Coder will present you with a temporary password for the site admin user; the


### PR DESCRIPTION
This is also a more-reliable way to get the initial admin password, as it can sometimes be lost in the logs after an install. A one-liner makes it easier to quickly fetch the password, while still documenting what is being ran.