### PR TITLE
Correct `gpu-count` on WAC templates

### DIFF
--- a/workspaces/workspaces-as-code/templates.md
+++ b/workspaces/workspaces-as-code/templates.md
@@ -37,7 +37,7 @@ workspace:
     cpu: 4
     memory: 16
     disk: 128
-    gpuCount: 1
+    gpu-count: 1
     labels:
       com.coder.custom.hello: "hello"
       com.coder.custom.world: "world"
@@ -115,7 +115,7 @@ workspace:
     com.coder.custom.world: world
 ```
 
-#### workspace.spec.gpucount
+#### workspace.spec.gpu-count
 
 The number of GPUs to allocate to the workspace.
 


### PR DESCRIPTION
The current `gpuCount` is not correct and it should be `gpu-count`.

Asking @Emyrk to review as we may be making additional changes to stay consistent, but for now I want to verify that I have things right in the template 👍 