### PR TITLE
Add CVM limitation on file systems

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,7 +1,0 @@
-# Dictionary.
-CVMs
-systemd
-Kubernetes
-Sysbox
-Istio
-NVIDIA

--- a/.spelling
+++ b/.spelling
@@ -1,0 +1,7 @@
+# Dictionary.
+CVMs
+systemd
+Kubernetes
+Sysbox
+Istio
+NVIDIA

--- a/admin/workspace-management/cvms.md
+++ b/admin/workspace-management/cvms.md
@@ -19,6 +19,8 @@ as Docker and systemd, in their workspaces.
 - The cluster must allow privileged containers and `hostPath` mounts. Read more
   about why this is still secure [here](#security).
 
+**Note:** CVMs do not currently support NFS as a file system.
+
 **Note:** Coder doesn't support legacy versions of cluster-wide proxy services
 such as Istio.
 

--- a/admin/workspace-management/cvms.md
+++ b/admin/workspace-management/cvms.md
@@ -3,33 +3,31 @@ title: Docker in workspaces
 description: Learn how to enable support for secure Docker inside workspaces.
 ---
 
-If you're a site admin or a site manager, you can enable
-[container-based virtual machines (CVMs)](../../workspaces/cvms.md) as a
-workspace deployment option. CVMs allow users to run system-level programs, such
-as Docker and systemd, in their workspaces.
+If you're a site admin or a site manager, you can enable [container-based
+virtual machines (CVMs)](../../workspaces/cvms.md) as a workspace deployment
+option. CVMs allow users to run system-level programs, such as Docker and
+systemd, in their workspaces.
 
 ## Infrastructure requirements
 
-- CVMs leverage the
-  [Sysbox container runtime](https://github.com/nestybox/sysbox), so the
-  Kubernetes Node must run a supported Linux distro with the minimum kernel
-  version (see
-  [Sysbox distro compatibility](https://github.com/nestybox/sysbox/blob/master/docs/distro-compat.md)
+- CVMs leverage the [Sysbox container
+  runtime](https://github.com/nestybox/sysbox), so the Kubernetes Node must run
+  a supported Linux distro with the minimum kernel version (see [Sysbox distro
+  compatibility](https://github.com/nestybox/sysbox/blob/master/docs/distro-compat.md)
   for more information)
 - The cluster must allow privileged containers and `hostPath` mounts. Read more
   about why this is still secure [here](#security).
 
-**Note:** CVMs do not currently support NFS as a file system.
+> Coder doesn't support legacy versions of cluster-wide proxy services such as
+Istio, and CVMs do not currently support NFS as a file system.
 
-**Note:** Coder doesn't support legacy versions of cluster-wide proxy services
-such as Istio.
+### GPUs
 
-> NVIDIA GPUs can be added to CVMs on bare metal clusters only. This feature is
-> not supported on Google Kubernetes Engine or other cloud providers at this
-> time.
->
-> Support for NVIDIA [GPUs](gpu-acceleration.md) is in **beta**. We do not
-> support AMD GPUs at this time.
+NVIDIA GPUs can be added to CVMs on bare metal clusters only. This feature is
+not supported on Google Kubernetes Engine or other cloud providers at this time.
+
+Support for NVIDIA [GPUs](gpu-acceleration.md) is in **beta**. We do not support
+AMD GPUs at this time.
 
 ## Enabling CVMs in Coder
 


### PR DESCRIPTION
@kylecarbs and I just debugged an issue with a customer that was trying to use CVMs with `NFS` for a file system. This is not supported by CVMs and needs to be called out.

@khorne3 my only thing to add here potentially is changing the format of the `Note` since there's two `Note:` blocks now:

![image](https://user-images.githubusercontent.com/2894107/117190027-8145a900-ada4-11eb-9c5d-8aaee9078d75.png)