### PR TITLE
chore: ignore updates to marocchino/sticky-pull-request-comment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,10 @@ updates:
     commit-message:
       prefix: "chore"
     ignore:
-      # GitHub always delivers the latest versions for each major
-      # release tag, so handle updates manually
+      # These actions deliver the latest versions by updating the
+      # major release tag, so handle updates manually
       - dependency-name: "actions/*"
+      - dependency-name: "marocchino/sticky-pull-request-comment"
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -64,7 +64,7 @@ jobs:
           DEPLOY_URL: ${{ steps.preview.outputs.url }}
 
       - name: Comment Credentials
-        uses: marocchino/sticky-pull-request-comment@v2.1.0
+        uses: marocchino/sticky-pull-request-comment@v2
         if: always()
         with:
           header: codercom-preview-docs


### PR DESCRIPTION
The upstream author publishes updates to this action using the same
scheme as GitHub, where the v2 tag is updated to the latest release
of the 2.x series. Therefore, we can manage updates manually.