### PR TITLE
add storage & db requirements

### DIFF
--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -64,12 +64,17 @@ the block storage requested.
 ## Database
 
 Coder requires the use of a [PostgreSQL](https://www.postgresql.org) database to
-store metadata related to your deployment. By default, Coder will deploy a TimescaleDB
+store metadata related to your deployment.
+
+By default, Coder will deploy a TimescaleDB
 internal to your Kubernetes cluster. This is included for evaluation purposes _only_,
 as it is not backed up. For production deployments, we recommend using a PostgreSQL
 database _external_ to your cluster. You can connect Coder to your external database
 by [modifying the Helm chart](https://coder.com/docs/guides/admin/helm-charts) with
 the appropriate PostgreSQL values.
+
+If providing your own instance, a minimum version of PostgreSQL 11 is required with
+the `contrib` package installed.
 
 ## Network Policies
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -55,26 +55,26 @@ launches the Remote IDE in a pop-up window.
 
 ## Storage
 
-Coder requires the use of a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
-in your Kubernetes cluster to store the code written in user [workspaces](../workspaces/index.md).
-In particular, the block storage type is required for use by the Persistent
-Volume Claim (PVC), which is created at the time of workspace creation to mount
-the block storage requested.
+Coder requires the use of a [persistent
+volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) in your
+Kubernetes cluster to store [workspaces](../workspaces/index.md) data. More
+specifically, the persistent volume claim (PVC) requires the block storage type
+(the PVC is created when you create the workspace to mount the requested block
+storage).
 
 ## Database
 
-Coder requires the use of a [PostgreSQL](https://www.postgresql.org) database to
+Coder requires a [PostgreSQL](https://www.postgresql.org) database to
 store metadata related to your deployment.
 
-By default, Coder will deploy a TimescaleDB
-internal to your Kubernetes cluster. This is included for evaluation purposes _only_,
-as it is not backed up. For production deployments, we recommend using a PostgreSQL
-database _external_ to your cluster. You can connect Coder to your external database
-by [modifying the Helm chart](https://coder.com/docs/guides/admin/helm-charts) with
-the appropriate PostgreSQL values.
+By default, Coder deploys a TimescaleDB internal to your Kubernetes cluster.
+This is included for evaluation purposes _only_, and it is _not_ backed up. For
+production deployments, we recommend using a PostgreSQL database _external_ to
+your cluster. You can connect Coder to your external database by [modifying the
+Helm chart](../guides/admin/helm-charts.md) with information regarding your
+PostgreSQL instance.
 
-If providing your own instance, a minimum version of PostgreSQL 11 is required with
-the `contrib` package installed.
+Coder requires, at minimum, PostgreSQL 11 with the `contrib` package installed.
 
 ## Network Policies
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -53,6 +53,24 @@ currently require the following versions _or newer_:
 If you're using [Remote IDEs](../workspaces/editors.md), allow pop-ups; Coder
 launches the Remote IDE in a pop-up window.
 
+## Storage
+
+Coder requires the use of a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+in your Kubernetes cluster to store the code written in user [workspaces](../workspaces/index.md).
+In particular, the block storage type is required for use by the Persistent
+Volume Claim (PVC), which is created at the time of workspace creation to mount
+the block storage requested.
+
+## Database
+
+Coder requires the use of a [PostgreSQL](https://www.postgresql.org) database to
+store metadata related to your deployment. By default, Coder will deploy a TimescaleDB
+internal to your Kubernetes cluster. This is included for evaluation purposes _only_,
+as it is not backed up. For production deployments, we recommend using a PostgreSQL
+database _external_ to your cluster. You can connect Coder to your external database
+by [modifying the Helm chart](https://coder.com/docs/guides/admin/helm-charts) with
+the appropriate PostgreSQL values.
+
 ## Network Policies
 
 Coder uses


### PR DESCRIPTION
adding storage requirement info, specifically around the use of PVCs and block storage. also reiterating our recommendation of using an external PostgreSQL instance for production deploys, and noting the minimum version required.

open to feedback & word-smithing.