### PR TITLE
add steps for installing coder in an archive

### DIFF
--- a/guides/deployments/archive-install.md
+++ b/guides/deployments/archive-install.md
@@ -1,0 +1,29 @@
+---
+title: Install Coder from an archive
+description: Learn how to install Coder from an archive
+---
+
+You can install Coder from an archive instead of using Helm. To do so, replace
+**steps 1-2** of the [Installation guide](../../setup/installation.md) with the
+following three steps, then proceed with the remaining steps in the Installation
+guide as written:
+
+1. Add the Coder Helm repo:
+
+   ```console
+   helm repo add coder https://helm.coder.com
+   ```
+
+1. Pull the `tar` file, which will be written to `./coder-<version>.tgz`:
+
+   ```console
+   helm pull coder/coder
+   ```
+
+1. Install Coder from the archive:
+
+   ```console
+   helm install coder coder-<version>.tgz \
+      --namespace=coder
+      --values=<my-values.yaml>
+   ```

--- a/guides/deployments/archive-install.md
+++ b/guides/deployments/archive-install.md
@@ -5,7 +5,7 @@ description: Learn how to install Coder from an archive
 
 You can install Coder from an archive instead of using Helm. To do so, replace
 **steps 1-2** of the [Installation guide](../../setup/installation.md) with the
-following three steps, then proceed with the remaining steps in the Installation
+following three steps, then proceed with the remainder of the Installation
 guide as written:
 
 1. Add the Coder Helm repo:
@@ -14,13 +14,13 @@ guide as written:
    helm repo add coder https://helm.coder.com
    ```
 
-1. Pull the `tar` file, which will be written to `./coder-<version>.tgz`:
+2. Pull the `tar` file, which will be written to `./coder-<version>.tgz`:
 
    ```console
    helm pull coder/coder
    ```
 
-1. Install Coder from the archive:
+3. Install Coder from the archive:
 
    ```console
    helm install coder coder-<version>.tgz \

--- a/guides/deployments/archive-install.md
+++ b/guides/deployments/archive-install.md
@@ -14,13 +14,13 @@ guide as written:
    helm repo add coder https://helm.coder.com
    ```
 
-2. Pull the `tar` file, which will be written to `./coder-<version>.tgz`:
+1. Pull the `tar` file, which will be written to `./coder-<version>.tgz`:
 
    ```console
    helm pull coder/coder
    ```
 
-3. Install Coder from the archive:
+1. Install Coder from the archive:
 
    ```console
    helm install coder coder-<version>.tgz \

--- a/manifest.json
+++ b/manifest.json
@@ -299,16 +299,19 @@
           "navigable": false,
           "children": [
             {
-              "path": "./guides/deployments/keycloak.md"
+              "path": "./guides/deployments/archive-install.md"
             },
             {
               "path": "./guides/deployments/code-server.md"
             },
             {
-              "path": "./guides/deployments/teardown.md"
+              "path": "./guides/deployments/postgres.md"
             },
             {
-              "path": "./guides/deployments/postgres.md"
+              "path": "./guides/deployments/keycloak.md"
+            },
+            {
+              "path": "./guides/deployments/teardown.md"
             }
           ]
         },

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -49,24 +49,6 @@ kubectl config set-context --current --namespace=coder
    helm install coder coder/coder --namespace coder
    ```
 
-## Installing Coder into an archive
-
-1. Add the Coder Helm repo, as referenced above in Step 1
-
-1. Pull the tar file, which will write to `./coder-<version>.tgz`
-
-   ```console
-   helm pull coder/coder
-   ```
-
-1. Install Coder from the archive
-
-   ```console
-   helm install coder coder-<version>.tgz \
-      --namespace=coder
-      --values=<my-values.yaml>
-   ```
-
    **Steps 3-5 are optional for non-production deployments.**
 
 1. Get a copy of your Helm chart so that you can modify it; you'll need to

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -49,6 +49,24 @@ kubectl config set-context --current --namespace=coder
    helm install coder coder/coder --namespace coder
    ```
 
+## Installing Coder into an archive
+
+1. Add the Coder Helm repo, as referenced above in Step 1
+
+2. Pull the tar file, which will write to `./coder-<version>.tgz`
+
+   ```console
+   helm pull coder/coder
+   ```
+
+3. Install Coder from the archive
+
+   ```console
+   helm install coder coder-<version>.tgz \
+      --namespace=coder
+      --values=<my-values.yaml>
+   ```
+
    **Steps 3-5 are optional for non-production deployments.**
 
 1. Get a copy of your Helm chart so that you can modify it; you'll need to

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -53,13 +53,13 @@ kubectl config set-context --current --namespace=coder
 
 1. Add the Coder Helm repo, as referenced above in Step 1
 
-2. Pull the tar file, which will write to `./coder-<version>.tgz`
+1. Pull the tar file, which will write to `./coder-<version>.tgz`
 
    ```console
    helm pull coder/coder
    ```
 
-3. Install Coder from the archive
+1. Install Coder from the archive
 
    ```console
    helm install coder coder-<version>.tgz \


### PR DESCRIPTION
adding steps for pulling down the helm chart & installing Coder in an archive, as a customer has run into this issue. @sreya provided the steps (included in this PR) as a solution to the customer.