### PR TITLE
chore: update workflows to build from main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,16 @@
 name: Quality
+
 on:
   push:
     branches:
-      - master
+      - main
+
   pull_request:
     branches:
-      - master
+      - main
+
   workflow_dispatch:
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,8 +1,10 @@
 name: Preview
+
 on:
   pull_request:
     branches:
-      - master
+      - main
+
 jobs:
   preview:
     name: Preview


### PR DESCRIPTION
Update the branch names from master to main for the GitHub Actions
workflows. (Closes: #245)

Once this is approved, I will rename the default branch from master to main and then merge this change.