### PR TITLE
fix: update coder sh to ssh

### DIFF
--- a/cli/remote-terminal.md
+++ b/cli/remote-terminal.md
@@ -9,7 +9,7 @@ the `coder ssh` command.
 ## Usage
 
 ```console
-$ coder ssh <workspace name> [<command [args...]>]
+coder ssh <workspace name> [<command [args...]>]
 ```
 
 This executes a remote command on the workspace; if no command is specified, the

--- a/cli/remote-terminal.md
+++ b/cli/remote-terminal.md
@@ -4,12 +4,12 @@ description: Learn how to use the Coder CLI to access your workspace.
 ---
 
 You can access the shell of your Coder workspace from your local computer using
-the CLI's `coder sh` command.
+the `coder ssh` command.
 
 ## Usage
 
-```shell
-coder sh <env name> [<command [args...]>]
+```console
+$ coder ssh <workspace name> [<command [args...]>]
 ```
 
 This executes a remote command on the workspace; if no command is specified, the
@@ -18,7 +18,7 @@ CLI opens up the workspace's default shell.
 For example, you can print "Hello World" in your Coder workspace shell as
 follows:
 
-```shell
-coder sh my-env echo "hello world"
+```console
+$ coder ssh my-workspace echo "hello world"
 hello world
 ```

--- a/workspaces/ssh.md
+++ b/workspaces/ssh.md
@@ -3,12 +3,13 @@ title: "SSH access"
 description: Learn how to configure SSH access to your workspaces.
 ---
 
-Before using, configuring, and accessing your workspace via SSH:
+Before accessing your workspace via SSH:
 
-- Your site manager must _not_ have
-  [disabled access](../admin/workspace-management/ssh-access.md) via SSH
-- You must have the [Coder CLI](../cli/index.md) installed on your local machine
-  before proceeding.
+- Your site manager must [enable access to workspaces using SSH]
+- You must install the [Coder CLI] on your local machine
+
+[enable access to workspaces using SSH]: ../admin/workspace-management/ssh-access.md
+[Coder CLI]: ../cli/index.md
 
 ## Configuration
 
@@ -45,12 +46,12 @@ SFTP, run `sftp coder.<workspace_name>`.
 
 You can use `rsync` to transfer files to and from Coder.
 
-To do so, use the flag `-e "coder sh"` in your `rsync` transfer invokation. For
+To do so, use the flag `-e "coder ssh"` in your `rsync` transfer invokation. For
 example, the following shows how you can transfer your home directory to your
 workspace:
 
 ```console
-rsync -e "coder sh" -a --progress ~/. my-env:~
+rsync -e "coder ssh" -a --progress ~/. my-env:~
 ```
 
 ## Forwarding dev URLs


### PR DESCRIPTION
Update documentation to reflect the preferred usage of our shell
invocation command, coder ssh. The coder sh command is an alias
to this command.