### PR TITLE
update Route53 annotation value

### DIFF
--- a/guides/ssl-certificates/route53.md
+++ b/guides/ssl-certificates/route53.md
@@ -145,7 +145,7 @@ helm install coder coder/coder --namespace coder \
   --set ingress.tls.devUrlsHostSecretName=devUrlCertificate \
   --set ingress.tls.hostSecretName=hostCertificate \
   --set \
-  "ingress.additionalAnnotations[0]=cert-manager.io/cluster-issuer:letsencrypt" \
+  --set "ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt" \
   --wait
 ```
 

--- a/guides/ssl-certificates/route53.md
+++ b/guides/ssl-certificates/route53.md
@@ -145,7 +145,7 @@ helm install coder coder/coder --namespace coder \
   --set ingress.tls.devUrlsHostSecretName=devUrlCertificate \
   --set ingress.tls.hostSecretName=hostCertificate \
   --set \
-  --set "ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt" \
+  --set ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt \
   --wait
 ```
 


### PR DESCRIPTION
updating the `helm install` command on Route53 docs to remove the now deprecated `additionalAnnotations` value and replace with `annotations`.