### PR TITLE
call out GPU nodes

### DIFF
--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -30,6 +30,9 @@ needs for the workspaces they run. See our guide on [compute resources](../../gu
 If you are expecting to provision GPUs to Coder workspaces, you must use an EC2 instance
 from the [AWS Accelerated Computing instance family](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html).
 
+_Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
+_running in a bare-metal Kubernetes environment._
+
 ## Preliminary steps
 
 Before you can create a cluster, you'll need to perform the following to set up

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -23,15 +23,18 @@ machine:
 
 ## Node Considerations
 
-The node type and size you select can impact on how you use the Coder platform.
-Take into account the number of developers expected to use Coder and the resource
-needs for the workspaces they run. See our guide on [compute resources](../../guides/admin/resources.md).
+The node type and size that you select impact how you use Coder. When choosing,
+be sure to account for the number of developers you expect to use Coder, as well
+as the resources they need to run their workspaces. See our guide on on [compute
+resources](../../guides/admin/resources.md) for additional information.
 
-If you are expecting to provision GPUs to Coder workspaces, you must use an EC2 instance
-from the [AWS Accelerated Computing instance family](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html).
+If you expect to provision GPUs to your Coder workspaces, you **must** use an
+EC2 instance from AWS' [accelerated computing instance
+family](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html).
 
-_Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
-_running in a bare-metal Kubernetes environment._
+> GPUs are not supported in workspaces deployed as [container-based virtual
+> machines (CVMs)](../../workspaces/cvms.md) unless you're running Coder in a
+> bare-metal Kubernetes environment.
 
 ## Preliminary steps
 

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -21,6 +21,15 @@ machine:
   to fast-track this process
 - [eksctl command-line utility](https://docs.aws.amazon.com/eks/latest/userguide/eksctl.html)
 
+## Node Considerations
+
+The node type and size you select can impact on how you use the Coder platform.
+Take into account the number of developers expected to use Coder and the resource
+needs for the workspaces they run. See our guide on [compute resources](../../guides/admin/resources.md).
+
+If you are expecting to provision GPUs to Coder workspaces, you must use an EC2 instance
+from the [AWS Accelerated Computing instance family](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/accelerated-computing-instances.html).
+
 ## Preliminary steps
 
 Before you can create a cluster, you'll need to perform the following to set up

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -24,6 +24,9 @@ needs for the workspaces they run. See our guide on [compute resources](../../gu
 If you are expecting to provision GPUs to Coder workspaces, you must use an Azure
 Virtual Machine with support for GPUs. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu).
 
+_Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
+_running in a bare-metal Kubernetes environment._
+
 ## Step 1: Create the resource group
 
 To make subsequent steps easier, start by creating environment variables for the

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -17,15 +17,19 @@ the prompts).
 
 ## Node Considerations
 
-The node type and size you select can impact on how you use the Coder platform.
-Take into account the number of developers expected to use Coder and the resource
-needs for the workspaces they run. See our guide on [compute resources](../../guides/admin/resources.md).
+The node type and size that you select impact how you use Coder. When choosing,
+be sure to account for the number of developers you expect to use Coder, as well
+as the resources they need to run their workspaces. See our guide on on [compute
+resources](../../guides/admin/resources.md) for additional information.
 
-If you are expecting to provision GPUs to Coder workspaces, you must use an Azure
-Virtual Machine with support for GPUs. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu).
+If you expect to provision GPUs to your Coder workspaces, you **must** use an
+Azure Virtual Machine with support for GPUs. See the [Azure
+documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu)
+for more information.
 
-_Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
-_running in a bare-metal Kubernetes environment._
+> GPUs are not supported in workspaces deployed as [container-based virtual
+> machines (CVMs)](../../workspaces/cvms.md) unless you're running Coder in a
+> bare-metal Kubernetes environment.
 
 ## Step 1: Create the resource group
 

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -15,6 +15,15 @@ Please make sure that you have the
 installed on your machine and that you've logged in (run `az login` and follow
 the prompts).
 
+## Node Considerations
+
+The node type and size you select can impact on how you use the Coder platform.
+Take into account the number of developers expected to use Coder and the resource
+needs for the workspaces they run. See our guide on [compute resources](../../guides/admin/resources.md).
+
+If you are expecting to provision GPUs to Coder workspaces, you must use an Azure
+Virtual Machine with support for GPUs. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-gpu).
+
 ## Step 1: Create the resource group
 
 To make subsequent steps easier, start by creating environment variables for the

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -19,17 +19,20 @@ assistance selecting the correct options for your cluster.
 
 ## Node Considerations
 
-The node type and size you select can impact on how you use the Coder platform.
-Take into account the number of developers expected to use Coder and the resource
-needs for the workspaces they run. See our guide on [compute resources](../../guides/admin/resources.md).
+The node type and size that you select impact how you use Coder. When choosing,
+be sure to account for the number of developers you expect to use Coder, as well
+as the resources they need to run their workspaces. See our guide on on [compute
+resources](../../guides/admin/resources.md) for additional information.
 
-If you are expecting to provision GPUs to Coder workspaces, you must use a general-
-purpose [N1 machine type](https://cloud.google.com/compute/docs/machine-types#gpus)
-in your GKE cluster and add GPUs to the nodes. We recommend doing this in a separate
+If you expect to provision GPUs to your Coder workspaces, you **must** use a
+general-purpose [N1 machine
+type](https://cloud.google.com/compute/docs/machine-types#gpus) in your GKE
+cluster and add GPUs to the nodes. We recommend doing this in a separate
 GPU-specific node pool.
 
-_Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
-_running in a bare-metal Kubernetes environment._
+> GPUs are not supported in workspaces deployed as [container-based virtual
+> machines (CVMs)](../../workspaces/cvms.md) unless you're running Coder in a
+> bare-metal Kubernetes environment.
 
 ## Set up the GKE cluster
 

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -25,7 +25,8 @@ needs for the workspaces they run. See our guide on [compute resources](../../gu
 
 If you are expecting to provision GPUs to Coder workspaces, you must use a general-
 purpose [N1 machine type](https://cloud.google.com/compute/docs/machine-types#gpus)
-in your GKE cluster.
+in your GKE cluster and add GPUs to the nodes. We recommend doing this in a separate
+GPU-specific node pool.
 
 _Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
 _running in a bare-metal Kubernetes environment._

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -27,6 +27,9 @@ If you are expecting to provision GPUs to Coder workspaces, you must use a gener
 purpose [N1 machine type](https://cloud.google.com/compute/docs/machine-types#gpus)
 in your GKE cluster.
 
+_Note: GPUs are not supported in Container-based Virtual Machine workspaces unless_
+_running in a bare-metal Kubernetes environment._
+
 ## Set up the GKE cluster
 
 The following two sections will show you how to spin up a Kubernetes cluster

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -17,6 +17,16 @@ Alternatively, you can
 instead of the gcloud CLI. Please refer to the sample CLI commands below for
 assistance selecting the correct options for your cluster.
 
+## Node Considerations
+
+The node type and size you select can impact on how you use the Coder platform.
+Take into account the number of developers expected to use Coder and the resource
+needs for the workspaces they run. See our guide on [compute resources](../../guides/admin/resources.md).
+
+If you are expecting to provision GPUs to Coder workspaces, you must use a general-
+purpose [N1 machine type](https://cloud.google.com/compute/docs/machine-types#gpus)
+in your GKE cluster.
+
 ## Set up the GKE cluster
 
 The following two sections will show you how to spin up a Kubernetes cluster


### PR DESCRIPTION
calling out node types that support GPUs, by referencing each cloud provider's respective documentation. also briefly touching on node sizing, and referencing our Compute Resources guide.