### PR TITLE
chore: Add information re: cluster sizing reqs

### DIFF
--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -18,14 +18,14 @@ to help you estimate:
 - **Development using VS Code with an SSH connection to Coder**: 1 CPU core and
   1 GB of RAM per developer
 
-> These estimates can vary greatly based on actual usage within a developer
-> workspace. We recommend starting with the resources you would allocate to a
-> developer's local workspace, then iterate as needed.
->  
-> We also recommend [monitoring](../guides/admin/usage-monitoring.md) your usage
-> to determine whether you should change your resource allocation.
-> Accepting a peak utilization of RAM of around 50% and CPU of around 70% is
-> a good way to balance performance with cost.
+These estimates can vary based on actual usage within a workspace. We recommend
+starting with the amount of resources you'd allocate to a local workspace, then
+iterating as needed.
+
+We also recommend [monitoring](../guides/admin/usage-monitoring.md) your usage
+to determine whether you should change your resource allocation. Accepting a
+peak utilization of RAM of around 50% and CPU of around 70% is a good way to
+balance performance with cost.
 
 ### Throughput
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -17,9 +17,15 @@ to help you estimate:
   storage per developer
 - **Development using VS Code with an SSH connection to Coder**: 1 CPU core and
   1 GB of RAM per developer
-
-> We recommend [monitoring](../guides/admin/usage-monitoring.md) your usage to
-determine whether you should change your resource allocation.
+  
+> These estimates can vary greatly based on actual usage within a developer
+> workspace. We recommend starting with the resources you would allocate to a
+> developer's local workspace, then iterate as needed.
+> 
+> We also recommend [monitoring](../guides/admin/usage-monitoring.md) your usage to
+> determine whether you should change your resource allocation.
+> Accepting a peak utilization of RAM of around 50% and CPU of around 70% is
+> a good way to balance performance with cost.
 
 ### Throughput
 

--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -17,13 +17,13 @@ to help you estimate:
   storage per developer
 - **Development using VS Code with an SSH connection to Coder**: 1 CPU core and
   1 GB of RAM per developer
-  
+
 > These estimates can vary greatly based on actual usage within a developer
 > workspace. We recommend starting with the resources you would allocate to a
 > developer's local workspace, then iterate as needed.
-> 
-> We also recommend [monitoring](../guides/admin/usage-monitoring.md) your usage to
-> determine whether you should change your resource allocation.
+>  
+> We also recommend [monitoring](../guides/admin/usage-monitoring.md) your usage
+> to determine whether you should change your resource allocation.
 > Accepting a peak utilization of RAM of around 50% and CPU of around 70% is
 > a good way to balance performance with cost.
 


### PR DESCRIPTION
This PR attempts to add some additional recommendations around sizing. A common ask of our customers is what size of a node (and how many nodes) they should have in their cluster for `x` number of developers.

This is very difficult to determine, as the work a developer is doing within their environment can vary greatly, requiring a different amount of resources. This PR addresses that with giving recommendations of initial sizing + measuring and iterating to right size it over time.

[ch13598]

@khorne3 I continued the "quote" block we had here, but the design of that may look weird with so much text in a "quote" block. Let me know if you'd like that pulled out into normal text or something else. 👍  See below screenshot of the large quote block:

![image](https://user-images.githubusercontent.com/2894107/121052673-37bff380-c780-11eb-8168-3cfdd5dbf946.png)