### PR TITLE
chore: Remove "peak" from requirements

### DIFF
--- a/setup/requirements.md
+++ b/setup/requirements.md
@@ -24,7 +24,7 @@ iterating as needed.
 
 We also recommend [monitoring](../guides/admin/usage-monitoring.md) your usage
 to determine whether you should change your resource allocation. Accepting a
-peak utilization of RAM of around 50% and CPU of around 70% is a good way to
+utilization of RAM of around 50% and CPU of around 70% is a good way to
 balance performance with cost.
 
 ### Throughput


### PR DESCRIPTION
This just removes the `peak` terminology [as requested](https://github.com/cdr/docs/pull/390/files/0c396b66a47ab0672a6e5f7023cae5493ef76584#r647035656) to remove ambiguity.