### PR TITLE
Avoid pulling full values file during install

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "format:check": "prettier --check '**/*.{css,html,js,json,jsx,ts,tsx,yaml,yml}'",
     "format:write": "prettier --write '**/*.{css,html,js,json,jsx,ts,tsx,yaml,yml}'",
     "lint": "markdownlint --config .markdownlint.jsonc --rules .markdownlint-rules '**/*.md'",
-    "lint:fix": "markdownlint --fix '**/*.md'"
+    "lint:fix": "markdownlint --config .markdownlint.jsonc --rules .markdownlint-rules --fix '**/*.md'"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.1",

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -46,13 +46,13 @@ kubectl config set-context --current --namespace=coder
    `helm search repo coder -l`)
 
    ```console
-   helm install coder coder/coder -n coder --version=<VERSION>
+   helm install coder coder/coder -namespace coder --version=<VERSION>
    ```
 
    **Steps 3-5 are optional for non-production deployments.**
 
 1. Get a copy of your Helm config values so that you can modify it; you'll need
-   to modify the Helm chart to update your PostgreSQL databases (step 4) and
+   to modify these values to update your PostgreSQL databases (step 4) and
    enable dev URLs (step 5):
 
    a. Get a copy of your existing Helm values and save it as `values.yaml`:
@@ -60,8 +60,8 @@ kubectl config set-context --current --namespace=coder
 
    b. Edit the `values.yaml` file as needed.
 
-   > View the
-   > [configuration options available in the `values.yaml` file.](https://github.com/cdr/enterprise-helm#values)
+   > View the [configuration options available in the `values.yaml`
+   > file.](https://github.com/cdr/enterprise-helm#values)
 
    c. Upgrade/install your Coder deployment with the updated Helm chart (be sure
    to replace the placeholder value with your Coder version). **This must be

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -46,7 +46,7 @@ kubectl config set-context --current --namespace=coder
    `helm search repo coder -l`)
 
    ```console
-   helm install coder coder/coder --namespace coder
+   helm install coder coder/coder -n coder --version=<VERSION>
    ```
 
    **Steps 3-5 are optional for non-production deployments.**

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -103,7 +103,7 @@ kubectl config set-context --current --namespace=coder
    > Running this command could potentially expose your database password to
    > other users on your system through `/proc`. If this is a concern, you can
    > use `--from-file=password=/dev/stdin` instead of `--from-literal=...` to
-   > enter your password, and hit `Ctrl+D` when you're done to submit it.
+   > enter your password and press `Ctrl+D` when you're done to submit it.
 
    You can find/define these values in your
    [PostgreSQL server configuration file](https://www.postgresql.org/docs/current/config-setting.html).

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -46,7 +46,7 @@ kubectl config set-context --current --namespace=coder
    `helm search repo coder -l`)
 
    ```console
-   helm install coder coder/coder -namespace coder --version=<VERSION>
+   helm install coder coder/coder --namespace coder --version=<VERSION>
    ```
 
    **Steps 3-5 are optional for non-production deployments.**
@@ -55,20 +55,20 @@ kubectl config set-context --current --namespace=coder
    to modify these values to update your PostgreSQL databases (step 4) and
    enable dev URLs (step 5):
 
-   a. Get a copy of your existing Helm values and save it as `values.yaml`:
-   `helm get values coder -n coder | tail -n +2 > values.yaml`
+   a. Create an empty file called `values.yaml` which will contain your
+   deployment configuration options.
 
    b. Edit the `values.yaml` file as needed.
 
-   > View the [configuration options available in the `values.yaml`
-   > file.](https://github.com/cdr/enterprise-helm#values)
+   > View the
+   > [configuration options available in the `values.yaml` file.](https://github.com/cdr/enterprise-helm#values)
 
    c. Upgrade/install your Coder deployment with the updated Helm chart (be sure
    to replace the placeholder value with your Coder version). **This must be
    done whenever you update the Helm chart:**
 
    ```console
-   helm upgrade coder coder/coder -n coder --version=<VERSION> --values values.yaml
+   helm upgrade coder coder/coder --namespace coder --version=<VERSION> --values values.yaml
    ```
 
    > If you omit `--version`, you'll upgrade to the latest version, excluding
@@ -79,7 +79,7 @@ kubectl config set-context --current --namespace=coder
    > presence of `-rc` in the version number (e.g., `1.16.0-rc.1`).
 
 1. Ensure that you have superuser privileges to your PostgreSQL database. Add
-   the following to your Helm chart so that Coder uses your external PostgreSQL
+   the following to your Helm values so that Coder uses your external PostgreSQL
    databases:
 
    ```yaml
@@ -94,8 +94,16 @@ kubectl config set-context --current --namespace=coder
    ```
 
    To create the `passwordSecret`, run
-   `echo "UserDefinedPassword" | kubectl create secret generic <NAME> --from-file=password=/dev/stdin`
+   `kubectl create secret generic <NAME> --from-literal="password=UserDefinedPassword"`
    (be sure to replace `UserDefinedPassword` with your actual password).
+
+   > Put a space before the command to prevent it from being saved in your shell
+   > history.
+   >
+   > Running this command could potentially expose your database password to
+   > other users on your system through `/proc`. If this is a concern, you can
+   > use `--from-file=password=/dev/stdin` instead of `--from-literal=...` to
+   > enter your password, and hit `Ctrl+D` when you're done to submit it.
 
    You can find/define these values in your
    [PostgreSQL server configuration file](https://www.postgresql.org/docs/current/config-setting.html).

--- a/setup/installation.md
+++ b/setup/installation.md
@@ -51,34 +51,32 @@ kubectl config set-context --current --namespace=coder
 
    **Steps 3-5 are optional for non-production deployments.**
 
-1. Get a copy of your Helm chart so that you can modify it; you'll need to
-   modify the Helm chart to update your PostgreSQL databases (step 4) and enable
-   dev URLs (step 5):
+1. Get a copy of your Helm config values so that you can modify it; you'll need
+   to modify the Helm chart to update your PostgreSQL databases (step 4) and
+   enable dev URLs (step 5):
 
-   a. Get a copy of your existing Helm chart and save it as `current-values.yaml`:
-   `helm show values coder/coder > current-values.yaml`
+   a. Get a copy of your existing Helm values and save it as `values.yaml`:
+   `helm get values coder -n coder | tail -n +2 > values.yaml`
 
-   b. Edit the `current-values.yaml` file as needed. Be sure to remove the lines
-   that you are _not_ modifying, otherwise the contents of `current-values.yaml`
-   will override those in the default chart.
+   b. Edit the `values.yaml` file as needed.
 
    > View the
    > [configuration options available in the `values.yaml` file.](https://github.com/cdr/enterprise-helm#values)
 
    c. Upgrade/install your Coder deployment with the updated Helm chart (be sure
-   to replace the placeholder value with your Coder version). **This must be done
-   whenever you update the Helm chart:**
+   to replace the placeholder value with your Coder version). **This must be
+   done whenever you update the Helm chart:**
 
    ```console
-   helm upgrade coder coder/coder -n coder --version=<VERSION> --values current-values.yaml
+   helm upgrade coder coder/coder -n coder --version=<VERSION> --values values.yaml
    ```
 
    > If you omit `--version`, you'll upgrade to the latest version, excluding
    > release candidates (RCs). To include RCs, provide the `--devel` flag.
    >
    > We do not provide documentation for RCs, and you should not use them unless
-   you've been instructed to do so by Coder. You can identify RCs by the
-   presence of `-rc` in the version number (e.g., `1.16.0-rc.1`).
+   > you've been instructed to do so by Coder. You can identify RCs by the
+   > presence of `-rc` in the version number (e.g., `1.16.0-rc.1`).
 
 1. Ensure that you have superuser privileges to your PostgreSQL database. Add
    the following to your Helm chart so that Coder uses your external PostgreSQL
@@ -96,14 +94,14 @@ kubectl config set-context --current --namespace=coder
    ```
 
    To create the `passwordSecret`, run
-   `kubectl create secret generic <NAME> --from-file=test=/dev/stdin`
+   `echo "UserDefinedPassword" | kubectl create secret generic <NAME> --from-file=password=/dev/stdin`
    (be sure to replace `UserDefinedPassword` with your actual password).
 
    You can find/define these values in your
    [PostgreSQL server configuration file](https://www.postgresql.org/docs/current/config-setting.html).
 
    > For more information, [see our guide](../guides/deployments/postgres.md) on
-   setting up a PostgreSQL instance.
+   > setting up a PostgreSQL instance.
 
 1. [Enable dev URL usage](../admin/devurls.md). Dev URLs allow users to access
    the web servers running in your workspace. To enable, provide a wildcard


### PR DESCRIPTION
Pulling full values file from the helm chart has stuff like `cemanager.image` etc. which we don't want the user to have in their values file unless they are specifically pulling images from another registry.