### PR TITLE
fix: helm variable names, annotations for AzureDNS & Route 53

### DIFF
--- a/guides/ssl-certificates/azureDNS.md
+++ b/guides/ssl-certificates/azureDNS.md
@@ -234,9 +234,9 @@ helm install coder coder/coder --namespace coder \
   --set devurls.host="*.exampleCo.com" \
   --set ingress.host="coder.exampleCo.com" \
   --set ingress.tls.enable=true \
-  --set ingress.tls.devUrlsHostSecretName=devUrlCertificate \
-  --set ingress.tls.hostSecretName=hostCertificate \
-  --set ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt \
+  --set ingress.tls.devurlsHostSecretName=coder-devurls-cert \
+  --set ingress.tls.hostSecretName=coder-root-cert \
+  --set ingress.annotations.cert-manager\.io/cluster-issuer="letsencrypt" \
   --wait
 ```
 

--- a/guides/ssl-certificates/azureDNS.md
+++ b/guides/ssl-certificates/azureDNS.md
@@ -236,7 +236,7 @@ helm install coder coder/coder --namespace coder \
   --set ingress.tls.enable=true \
   --set ingress.tls.devurlsHostSecretName=coder-devurls-cert \
   --set ingress.tls.hostSecretName=coder-root-cert \
-  --set ingress.annotations.cert-manager\.io/cluster-issuer="letsencrypt" \
+  --set ingress.annotations."cert-manager\.io/cluster-issuer"="letsencrypt" \
   --wait
 ```
 

--- a/guides/ssl-certificates/route53.md
+++ b/guides/ssl-certificates/route53.md
@@ -142,10 +142,9 @@ helm install coder coder/coder --namespace coder \
   --set devurls.host="*.exampleCo.com" \
   --set ingress.host="coder.exampleCo.com" \
   --set ingress.tls.enable=true \
-  --set ingress.tls.devUrlsHostSecretName=devUrlCertificate \
-  --set ingress.tls.hostSecretName=hostCertificate \
-  --set \
-  --set ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt \
+  --set ingress.tls.devurlsHostSecretName=coder-devurls-cert \
+  --set ingress.tls.hostSecretName=coder-root-cert \
+  --set ingress.annotations.cert-manager\.io/cluster-issuer="letsencrypt" \
   --wait
 ```
 

--- a/guides/ssl-certificates/route53.md
+++ b/guides/ssl-certificates/route53.md
@@ -144,7 +144,7 @@ helm install coder coder/coder --namespace coder \
   --set ingress.tls.enable=true \
   --set ingress.tls.devurlsHostSecretName=coder-devurls-cert \
   --set ingress.tls.hostSecretName=coder-root-cert \
-  --set ingress.annotations.cert-manager\.io/cluster-issuer="letsencrypt" \
+  --set ingress.annotations."cert-manager\.io/cluster-issuer"="letsencrypt" \
   --wait
 ```
 


### PR DESCRIPTION
same variable change as done in #348, while also adding quotations to the letsencrypt annotation. 