### PR TITLE
chore: use minimal permissions for workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,18 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,7 +12,7 @@ permissions:
   deployments: none
   issues: none
   packages: none
-  pull-requests: none
+  pull-requests: write
   repository-projects: none
   security-events: none
   statuses: none

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -5,6 +5,18 @@ on:
     branches:
       - main
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 jobs:
   preview:
     name: Preview


### PR DESCRIPTION
Restrict the GITHUB_TOKEN issued for builds to reads of respository
metadata and file contents.