### PR TITLE
chore: change WaC status from beta to alpha

### DIFF
--- a/workspaces/workspaces-as-code/code-completion.md
+++ b/workspaces/workspaces-as-code/code-completion.md
@@ -1,7 +1,7 @@
 ---
 title: "Workspace template code completion"
 description: "Learn how to use code completion when creating workspace templates."
-state: beta
+state: alpha
 ---
 
 Coder provides a [JSON Schema](https://json-schema.org/) for workspace templates

--- a/workspaces/workspaces-as-code/index.md
+++ b/workspaces/workspaces-as-code/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Workspaces as code"
 description: "Learn how to describe workspace configuration as code."
-state: beta
+state: alpha
 ---
 
 Workspaces as code (WAC) brings the _infrastructure as code_ paradigm to Coder

--- a/workspaces/workspaces-as-code/templates.md
+++ b/workspaces/workspaces-as-code/templates.md
@@ -1,7 +1,7 @@
 ---
 title: "Workspace templates"
 description: "Learn how to write a template for creating workspaces."
-state: beta
+state: alpha
 ---
 
 <!-- markdownlint-disable MD044 -->


### PR DESCRIPTION
Changing product + docs to consistently refer to WAC as alpha