### PR TITLE
Airgapped network instructions cert application command is wrong

### DIFF
--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -1,5 +1,5 @@
 ---
-title: Air-Gapped Deployment
+title: Air-gapped deployment
 description: Learn how to set up an air-gapped Coder deployment.
 ---
 

--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -58,7 +58,7 @@ platform images are hosted in Coder's Docker Hub repo.
 1. Pull down the Coder helm charts by running the following in a non-air-gapped
    workspace:
 
-   ```bash
+   ```console
    helm repo add coder https://helm.coder.com
    helm pull coder/coder
    ```
@@ -90,7 +90,7 @@ platform images are hosted in Coder's Docker Hub repo.
    You can pull each of these images from their `coderenvs/<img-name>:<version>`
    registry location using the image's name and Coder version:
 
-   ```bash
+   ```console
    docker pull coderenvs/coder-service:<version>
    ```
 
@@ -118,7 +118,7 @@ platform images are hosted in Coder's Docker Hub repo.
    your internal registry; this registry must be accessible from your air-gapped
    workspace. For example, to push `coder-service`:
 
-   ```bash
+   ```console
    docker tag coderenvs/coder-service:<version> my-registry.com/coderenvs/coder-service:<version>
    docker push my-registry.com/coderenvs/coder-service:<version>
    ```
@@ -141,7 +141,7 @@ platform images are hosted in Coder's Docker Hub repo.
 1. Once all of the resources are in your air-gapped network, run the following
    to deploy Coder to your Kubernetes cluster:
 
-   ```bash
+   ```console
    kubectl create namespace coder
    helm --namespace coder install coder /path/to/coder-X.Y.Z.tgz \
    --set cemanager.image=my-registry.com/coderenvs/coder-service:<version> \

--- a/setup/air-gapped/index.md
+++ b/setup/air-gapped/index.md
@@ -58,7 +58,7 @@ platform images are hosted in Coder's Docker Hub repo.
 1. Pull down the Coder helm charts by running the following in a non-air-gapped
    workspace:
 
-   ```console
+   ```bash
    helm repo add coder https://helm.coder.com
    helm pull coder/coder
    ```
@@ -90,7 +90,7 @@ platform images are hosted in Coder's Docker Hub repo.
    You can pull each of these images from their `coderenvs/<img-name>:<version>`
    registry location using the image's name and Coder version:
 
-   ```console
+   ```bash
    docker pull coderenvs/coder-service:<version>
    ```
 
@@ -118,7 +118,7 @@ platform images are hosted in Coder's Docker Hub repo.
    your internal registry; this registry must be accessible from your air-gapped
    workspace. For example, to push `coder-service`:
 
-   ```console
+   ```bash
    docker tag coderenvs/coder-service:<version> my-registry.com/coderenvs/coder-service:<version>
    docker push my-registry.com/coderenvs/coder-service:<version>
    ```
@@ -141,7 +141,7 @@ platform images are hosted in Coder's Docker Hub repo.
 1. Once all of the resources are in your air-gapped network, run the following
    to deploy Coder to your Kubernetes cluster:
 
-   ```console
+   ```bash
    kubectl create namespace coder
    helm --namespace coder install coder /path/to/coder-X.Y.Z.tgz \
    --set cemanager.image=my-registry.com/coderenvs/coder-service:<version> \

--- a/setup/air-gapped/infrastructure.md
+++ b/setup/air-gapped/infrastructure.md
@@ -69,7 +69,7 @@ container runtime, but here is a partial list to help you get started:
 If the cluster uses containerd, apply the following to patch in certificates for
 images in the local registry domain:
 
-```console
+```bash
 update-ca-certificates
 cat <<EOT >> /etc/containerd/config.toml
 [plugins."io.containerd.grpc.v1.cri".registry.configs."$REGISTRY_DOMAIN_NAME".tls]
@@ -99,7 +99,7 @@ To pass a self-signed certificate to Coder's images, you'll need to:
 
 To create a secret, run:
 
-```console
+```bash
 kubectl -n coder create secret generic local-registry-cert --from-file=/certs
 ```
 
@@ -113,7 +113,7 @@ becomes the secret **key**.
 
 To verify the new secret:
 
-```console
+```bash
 kubectl -n coder get secret local-registry-cert -o yaml
 ```
 
@@ -130,7 +130,7 @@ certs:
 Then, add the flag `-f registry-cert-values.yml` to the end of the `helm install`
 or `helm upgrade` command to include the new secrets file:
 
-```console
+```bash
 helm install --wait --atomic --debug --namespace coder coder . \
    --set cemanager.image=$REGISTRY_DOMAIN_NAME/coderenvs/coder-service:<version> \
    --set envproxy.image=$REGISTRY_DOMAIN_NAME/coderenvs/coder-service:<version> \
@@ -147,7 +147,7 @@ registry's static IP address. One way to do this without an external DNS server
 is to use the node's hosts file. For example, if the registry is on 10.0.0.2,
 then add this to the Node configuration script:
 
-```console
+```bash
 echo "10.0.0.2 $REGISTRY_DOMAIN_NAME" >> /etc/hosts
 ```
 

--- a/setup/air-gapped/infrastructure.md
+++ b/setup/air-gapped/infrastructure.md
@@ -127,11 +127,11 @@ certs:
     key: "registry.crt"
 ```
 
-Then, add the flag `-f registry-cert-values.yml` to the end of the secret
-verification immediately above:
+Then, add the flag `-f registry-cert-values.yml` to the end of the helm upgrade
+command to include the new secrets file:
 
 ```console
-kubectl -n coder get secret local-registry-cert -o yaml -f registry-cert-values.yml
+helm upgrade -n coder coder . -f current-values.yaml -f registry-cert-values.yml
 ```
 
 ### Resolving the registry using the cluster's DNS or hostAliases

--- a/setup/air-gapped/infrastructure.md
+++ b/setup/air-gapped/infrastructure.md
@@ -69,7 +69,7 @@ container runtime, but here is a partial list to help you get started:
 If the cluster uses containerd, apply the following to patch in certificates for
 images in the local registry domain:
 
-```bash
+```console
 update-ca-certificates
 cat <<EOT >> /etc/containerd/config.toml
 [plugins."io.containerd.grpc.v1.cri".registry.configs."$REGISTRY_DOMAIN_NAME".tls]
@@ -99,7 +99,7 @@ To pass a self-signed certificate to Coder's images, you'll need to:
 
 To create a secret, run:
 
-```bash
+```console
 kubectl -n coder create secret generic local-registry-cert --from-file=/certs
 ```
 
@@ -113,7 +113,7 @@ becomes the secret **key**.
 
 To verify the new secret:
 
-```bash
+```console
 kubectl -n coder get secret local-registry-cert -o yaml
 ```
 
@@ -130,7 +130,7 @@ certs:
 Then, add the flag `-f registry-cert-values.yml` to the end of the `helm install`
 or `helm upgrade` command to include the new secrets file:
 
-```bash
+```console
 helm install --wait --atomic --debug --namespace coder coder . \
    --set cemanager.image=$REGISTRY_DOMAIN_NAME/coderenvs/coder-service:<version> \
    --set envproxy.image=$REGISTRY_DOMAIN_NAME/coderenvs/coder-service:<version> \
@@ -147,7 +147,7 @@ registry's static IP address. One way to do this without an external DNS server
 is to use the node's hosts file. For example, if the registry is on 10.0.0.2,
 then add this to the Node configuration script:
 
-```bash
+```console
 echo "10.0.0.2 $REGISTRY_DOMAIN_NAME" >> /etc/hosts
 ```
 

--- a/setup/air-gapped/infrastructure.md
+++ b/setup/air-gapped/infrastructure.md
@@ -127,8 +127,8 @@ certs:
     key: "registry.crt"
 ```
 
-Then, add the flag `-f registry-cert-values.yml` to the end of the helm install
-or upgrade command to include the new secrets file:
+Then, add the flag `-f registry-cert-values.yml` to the end of the `helm install`
+or `helm upgrade` command to include the new secrets file:
 
 ```console
 helm install --wait --atomic --debug --namespace coder coder . \

--- a/setup/air-gapped/infrastructure.md
+++ b/setup/air-gapped/infrastructure.md
@@ -127,11 +127,17 @@ certs:
     key: "registry.crt"
 ```
 
-Then, add the flag `-f registry-cert-values.yml` to the end of the helm upgrade
-command to include the new secrets file:
+Then, add the flag `-f registry-cert-values.yml` to the end of the helm install
+or upgrade command to include the new secrets file:
 
 ```console
-helm upgrade -n coder coder . -f current-values.yaml -f registry-cert-values.yml
+helm install --wait --atomic --debug --namespace coder coder . \
+   --set cemanager.image=$REGISTRY_DOMAIN_NAME/coderenvs/coder-service:<version> \
+   --set envproxy.image=$REGISTRY_DOMAIN_NAME/coderenvs/coder-service:<version> \
+   --set envbox.image=$REGISTRY_DOMAIN_NAME/coderenvs/envbox:<version> \
+   --set timescale.image=$REGISTRY_DOMAIN_NAME/coderenvs/timescale:<version> \
+   --set dashboard.image=$REGISTRY_DOMAIN_NAME/coderenvs/dashboard:<version> \
+   -f registry-cert-values.yml
 ```
 
 ### Resolving the registry using the cluster's DNS or hostAliases

--- a/setup/air-gapped/infrastructure.md
+++ b/setup/air-gapped/infrastructure.md
@@ -1,5 +1,5 @@
 ---
-title: Network Setup
+title: Network setup
 description: Learn how to set up a network for air-gapped Coder deployment.
 ---
 


### PR DESCRIPTION
The cert application command needs to be a helm upgrade command rather than a kubectl get secret command. 