### PR TITLE
chore: update dependabot version ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,10 +9,16 @@ updates:
     commit-message:
       prefix: "chore"
     ignore:
-      # These actions deliver the latest versions by updating the
-      # major release tag, so handle updates manually
+      # These actions deliver the latest versions by updating the major
+      # release tag, so ignore minor and patch versions
       - dependency-name: "actions/*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
       - dependency-name: "marocchino/sticky-pull-request-comment"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -21,7 +27,10 @@ updates:
       time: "06:00"
       timezone: "America/Chicago"
     ignore:
+      # Ignore major updates to Node.js types, because they need to
+      # correspond to the Node.js engine version
       - dependency-name: "@types/node"
-        versions: ["15.x", "14.x", "13.x"]
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: "chore"


### PR DESCRIPTION
* Open pull requests for major version updates for GitHub Actions
* Ignore major version updates for Node.js types