### PR TITLE
link SSL cert guides in next steps

### DIFF
--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -231,4 +231,7 @@ For more information, see:
 
 ## Next steps
 
-At this point, you're ready to proceed to [installation](../installation.md).
+Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
+to access Coder through a secure domain.
+
+Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -231,7 +231,7 @@ For more information, see:
 
 ## Next steps
 
-Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
-to access Coder through a secure domain.
+To access Coder through a secure domain, review our guides on configuring and
+using [SSL certificates](../../guides/ssl-certificates/index.md).
 
 Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -139,7 +139,7 @@ For more information, see:
 
 ## Next steps
 
-Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
-to access Coder through a secure domain.
+To access Coder through a secure domain, review our guides on configuring and
+using [SSL certificates](../../guides/ssl-certificates/index.md).
 
 Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -139,4 +139,7 @@ For more information, see:
 
 ## Next steps
 
-At this point, you're ready to proceed to [installation](../installation.md).
+Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
+to access Coder through a secure domain.
+
+Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -150,4 +150,7 @@ For more information, see:
 
 ## Next steps
 
-At this point, you're ready to proceed to [installation](../installation.md).
+Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
+to access Coder through a secure domain.
+
+Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -150,7 +150,7 @@ For more information, see:
 
 ## Next steps
 
-Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
-to access Coder through a secure domain.
+To access Coder through a secure domain, review our guides on configuring and
+using [SSL certificates](../../guides/ssl-certificates/index.md).
 
 Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/k3s.md
+++ b/setup/kubernetes/k3s.md
@@ -137,7 +137,7 @@ cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 
 ## Next steps
 
-Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
-to access Coder through a secure domain.
+To access Coder through a secure domain, review our guides on configuring and
+using [SSL certificates](../../guides/ssl-certificates/index.md).
 
 Once complete, see our page on [installation](../installation.md).

--- a/setup/kubernetes/k3s.md
+++ b/setup/kubernetes/k3s.md
@@ -137,5 +137,7 @@ cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 
 ## Next steps
 
-At this point, you're ready to proceed to [installing
-Coder](../installation.md).
+Consider reviewing our guides on configuring [SSL certificates](../../guides/ssl-certificates/index.md)
+to access Coder through a secure domain.
+
+Once complete, see our page on [installation](../installation.md).


### PR DESCRIPTION
adding a link to the SSL guides in the `Next Steps` section of the k8s pages. this should better integrate the SSL guides with our install docs.

i'm hoping we can further build out this `Next Steps` section to include a variety of deployment routes/paths one can take when installing Coder. open to thoughts/suggestions.