### PR TITLE
Update references to ECDSA.

### DIFF
--- a/admin/git.md
+++ b/admin/git.md
@@ -23,7 +23,7 @@ Instead, you can use Visual Studio Code with git, the command-line tool, and we
 expect that this combination will work with most hosting software or services.
 However, Coder doesn't test these and cannot provide recommendations or support.
 
-**Note** The public key provided by Coder uses the ED25519 key algorithm. Ensure
+**Note** The public key provided by Coder uses the Ed25519 key algorithm. Ensure
 your git provider supports this.
 
 ![Configure Git Integration](../assets/admin/git-admin.png)

--- a/admin/git.md
+++ b/admin/git.md
@@ -23,7 +23,7 @@ Instead, you can use Visual Studio Code with git, the command-line tool, and we
 expect that this combination will work with most hosting software or services.
 However, Coder doesn't test these and cannot provide recommendations or support.
 
-**Note** The public key provided by Coder uses the ECDSA key algorithm. Ensure
+**Note** The public key provided by Coder uses the ED25519 key algorithm. Ensure
 your git provider supports this.
 
 ![Configure Git Integration](../assets/admin/git-admin.png)

--- a/changelog/1.21.0.md
+++ b/changelog/1.21.0.md
@@ -17,4 +17,5 @@ There are no bug fixes in 1.21.0.
 
 ### Security updates 🔐
 
-There are no security updates in 1.21.0.
+- ssh: New keys are generated using the [ED25519 digital signature algorithm](https://datatracker.ietf.org/doc/html/rfc8709)
+instead of the ECDSA digital signature algorithm.

--- a/changelog/1.21.0.md
+++ b/changelog/1.21.0.md
@@ -17,5 +17,6 @@ There are no bug fixes in 1.21.0.
 
 ### Security updates 🔐
 
-- ssh: New keys are generated using the [ED25519 digital signature algorithm](https://datatracker.ietf.org/doc/html/rfc8709)
-instead of the ECDSA digital signature algorithm.
+- ssh: New keys are generated using the [Ed25519 digital signature
+  algorithm](https://datatracker.ietf.org/doc/html/rfc8709) instead of the ECDSA
+  digital signature algorithm.

--- a/workspaces/preferences.md
+++ b/workspaces/preferences.md
@@ -40,10 +40,12 @@ need to access from your workspace.
 If necessary, you can regenerate your key. Be sure to provide your updated key
 to all of the services you use. Otherwise, they won't work.
 
-> The SSH public keys use the [ED25519 key algorithm](https://datatracker.ietf.org/doc/html/rfc8709)
+> The SSH public keys use the [Ed25519 key algorithm](https://datatracker.ietf.org/doc/html/rfc8709)
 > instead of the more commonly used RSA algorithm.
-> This provides you with a smaller, more performant key with the same level of
-> security as RSA.
+> Recent publications ([example](https://leanpub.com/gocrypto/read#leanpub-auto-chapter-5-digital-signatures))
+> suggest that Ed25519 is preferable to RSA.
+> OpenSSH has supported Ed25519 SSH keys since [version 6.5](https://www.openssh.com/txt/release-6.5),
+> released in 2014.
 
 ## Linked accounts
 

--- a/workspaces/preferences.md
+++ b/workspaces/preferences.md
@@ -40,9 +40,10 @@ need to access from your workspace.
 If necessary, you can regenerate your key. Be sure to provide your updated key
 to all of the services you use. Otherwise, they won't work.
 
-> The SSH public key uses the ECDSA key algorithm instead of the more commonly
-> used RSA key. This provides you with a smaller, more performant key with the
-> same level of security as RSA.
+> The SSH public keys use the [ED25519 key algorithm](https://datatracker.ietf.org/doc/html/rfc8709)
+> instead of the more commonly used RSA algorithm.
+> This provides you with a smaller, more performant key with the same level of
+> security as RSA.
 
 ## Linked accounts
 

--- a/workspaces/ssh.md
+++ b/workspaces/ssh.md
@@ -46,7 +46,7 @@ SFTP, run `sftp coder.<workspace_name>`.
 
 You can use `rsync` to transfer files to and from Coder.
 
-To do so, use the flag `-e "coder ssh"` in your `rsync` transfer invokation. For
+To do so, use the flag `-e "coder ssh"` in your `rsync` transfer invocation. For
 example, the following shows how you can transfer your home directory to your
 workspace:
 


### PR DESCRIPTION
* Update 1.21 security release notes with details of ECDSA -> ED25519 algorithm change
* Update existing references to ECDSA where applicable.
* Drive-by: fix typo