### PR TITLE
fix 1.19.1 release date

### DIFF
--- a/changelog/1.19.1.md
+++ b/changelog/1.19.1.md
@@ -1,6 +1,6 @@
 ---
 title: "1.19.1"
-description: "Released on 06/23/2021"
+description: "Released on 05/23/2021"
 ---
 
 ### Breaking changes ❗


### PR DESCRIPTION
changelog mentioned that `1.19.1` was released on 06/23/2021, which is _after_ the `1.20` release date. I assume the correct date is 05/23/2021, but if someone could double check, that would be great.