### PR TITLE
recommend default formatter and auto-format on save

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "davidanson.vscode-markdownlint",
-    "streetsidesoftware.code-spell-checker"
+    "streetsidesoftware.code-spell-checker",
+    "stkb.rewrap"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "editor.rulers": [80]
+  "editor.rulers": [80],
+  "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
+  "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.rulers": [80],
   "editor.defaultFormatter": "DavidAnson.vscode-markdownlint",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.markdownlint": true
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.markdownlint": true
-  }
+  },
+  "rewrap.autoWrap.enabled": true
 }


### PR DESCRIPTION
This repository recommends the `davidanson.vscode-markdownlint` extension and prompts the user to install it when they first clone the docs repo. However, the formatter will do nothing unless people set it to their default formatter and intermittently use the "format" command in the command palette or a keyboard shortcut.

This proposed PR will (for all users editing the docs with VS Code):
- set `davidanson.vscode-markdownlint` as the default formatter for this repo
- auto format (with this `davidanson.vscode-markdownlint`) whenever a file is saved

This should also lead to less linting issues from new contributors

Alternatives:
- document how someone can do this themselves on the README

I use the "prettier" extension for other projects and, while it always passes lint tests, it will try to "re-format" some docs. I found the issue was my default formatter wasn't set (or was reset) for this repo.