### PR TITLE
add admin pwd reset troubleshooting & manifest updates

### DIFF
--- a/guides/troubleshooting/admin-pwd.md
+++ b/guides/troubleshooting/admin-pwd.md
@@ -1,0 +1,26 @@
+---
+title: Resetting admin password
+description: Learn how to resolve errors resetting your admin password
+---
+
+When attempting to reset your Coder admin password in the terminal, you may
+encounter the following error:
+
+```console
+error: unable to upgrade connection: error dialing backend: remote error: tls:
+handshake failure
+```
+
+## Why this happens
+
+This upgrade error can occur when a proxy is in front of the `kube-apiserver`,
+which blocks your attempt to reach the `coderd` pod and reset the admin
+password.
+
+## Troubleshooting steps
+
+To properly access to the `coderd` pod, you'll need to either remove the proxy
+(if possible), or circumvent the proxy and make the call directly with `kubectl`.
+
+If this doesn't resolve the issue, please
+[contact us](https://coder.com/contact) for further support.

--- a/guides/troubleshooting/admin-pwd.md
+++ b/guides/troubleshooting/admin-pwd.md
@@ -1,10 +1,10 @@
 ---
-title: Resetting admin password
-description: Learn how to resolve errors resetting your admin password
+title: Admin password reset
+description: Learn how to resolve issues with resetting your admin password.
 ---
 
-When attempting to reset your Coder admin password in the terminal, you may
-encounter the following error:
+When resetting your Coder admin password in the terminal, you may encounter the
+following error:
 
 ```console
 error: unable to upgrade connection: error dialing backend: remote error: tls:
@@ -13,14 +13,14 @@ handshake failure
 
 ## Why this happens
 
-This upgrade error can occur when a proxy is in front of the `kube-apiserver`,
-which blocks your attempt to reach the `coderd` pod and reset the admin
-password.
+This upgrade-related error occurs when a proxy is in front of `kube-apiserver`,
+blocking your attempt to reach the `coderd` pod and reset the admin password.
 
 ## Troubleshooting steps
 
-To properly access to the `coderd` pod, you'll need to either remove the proxy
-(if possible), or circumvent the proxy and make the call directly with `kubectl`.
+To access the `coderd` pod properly, you'll need to remove the proxy. If
+removing the proxy isn't possible, circumvent the proxy and make the call to
+`coderd` directly using `kubectl`.
 
 If this doesn't resolve the issue, please
 [contact us](https://coder.com/contact) for further support.

--- a/guides/troubleshooting/docker-problems.md
+++ b/guides/troubleshooting/docker-problems.md
@@ -113,3 +113,6 @@ daemonset.apps "increase-limits" deleted
 
 However, note that the setting will persist until the node restarts or another
 program sets the `kernel.keys.maxkeys` and `kernel.keys.maxkeys` settings.
+
+If this doesn't resolve the issue, please
+[contact us](https://coder.com/contact) for further support.

--- a/guides/troubleshooting/git-oauth.md
+++ b/guides/troubleshooting/git-oauth.md
@@ -32,3 +32,6 @@ attempts to add your public key again to GitHub.
 If the steps above do not fix the problem, the error may be related to the
 GitHub configuration values set using Coder's **Admin** panel. Site managers can
 view and update these values at **Manage** > **Admin** > **Git OAuth**.
+
+If this doesn't resolve the issue, please
+[contact us](https://coder.com/contact) for further support.

--- a/guides/troubleshooting/inotify-watch-limits.md
+++ b/guides/troubleshooting/inotify-watch-limits.md
@@ -268,3 +268,6 @@ program sets the `fs.inotify.max_user_watches` setting.
   - [My ultimate VSCode configuration](https://dev.to/vaidhyanathan93/ulitmate-vscode-configuration-4i2o),
     a blog post describing a user's preferred settings, including file
     exclusions
+
+If none of these steps resolve the issue, please
+[contact us](https://coder.com/contact) for further support.

--- a/manifest.json
+++ b/manifest.json
@@ -384,7 +384,13 @@
           "path": "./guides/troubleshooting/index.md",
           "children": [
             {
+              "path": "./guides/troubleshooting/admin-pwd.md"
+            },
+            {
               "path": "./guides/troubleshooting/docker-problems.md"
+            },
+            {
+              "path": "./guides/troubleshooting/git-oauth.md"
             },
             {
               "path": "./guides/troubleshooting/registry.md"
@@ -394,12 +400,6 @@
             },
             {
               "path": "./guides/troubleshooting/502error.md"
-            },
-            {
-              "path": "./guides/troubleshooting/git-oauth.md"
-            },
-            {
-              "path": "./guides/troubleshooting/admin-pwd.md"
             }
           ]
         }

--- a/manifest.json
+++ b/manifest.json
@@ -394,6 +394,12 @@
             },
             {
               "path": "./guides/troubleshooting/502error.md"
+            },
+            {
+              "path": "./guides/troubleshooting/git-oauth.md"
+            },
+            {
+              "path": "./guides/troubleshooting/admin-pwd.md"
             }
           ]
         }


### PR DESCRIPTION
adding steps to troubleshoot an error seen when attempting to retrieve or reset the admin pwd behind a proxy. also added a previous troubleshooting card (#540) to the manifest