### PR TITLE
add programmatic dev URL access

### DIFF
--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -71,6 +71,19 @@ If, however, you named the dev URL `reactproject`, then your URL is
 If you access a dev URL that hasn't been created, Coder automatically adds it to
 your dev URL list on the dashboard and sets the access level to **Private**.
 
+## Programmatically accessing dev URLs
+
+If you need programmatic access to authenticated dev URLs (Private,
+Organization, or Authenticated Users), you can do the following:
+
+```console
+# Generate a token
+coder@dev ~ coder tokens create devurl
+<TOKEN>
+# Curl Dev URL
+coder@dev ~ curl --cookie "devurl_session=<TOKEN>" <dev-url>
+```
+
 ## Access via SSH port forwarding
 
 You can also access your server via [SSH port forwarding](ssh.md#forwarding-dev-urls).

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -81,6 +81,7 @@ you can run the following in the terminal:
 # Generate an API token with the Coder CLI
 $ coder tokens create devurl
 <TOKEN>
+
 # Send HTTP requests to the dev URL using the devurl_session cookie
 $ curl --cookie "devurl_session=<TOKEN>" <dev-url>
 ```

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -74,7 +74,7 @@ your dev URL list on the dashboard and sets the access level to **Private**.
 ## Programmatically accessing dev URLs
 
 If you need programmatic access to authenticated dev URLs (Private,
-Organization, or Authenticated Users), you can do the following:
+Organization, or Authenticated Users), you can run the following commands:
 
 ```console
 # Generate a token

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -77,10 +77,10 @@ If you need programmatic access to authenticated dev URLs (Private,
 Organization, or Authenticated Users), you can run the following commands:
 
 ```console
-# Generate a token
+# Generate an API token with the coder-cli
 coder@dev ~ coder tokens create devurl
 <TOKEN>
-# Curl Dev URL
+# Send HTTP requests to the dev URL with the devurl_session cookie
 coder@dev ~ curl --cookie "devurl_session=<TOKEN>" <dev-url>
 ```
 

--- a/workspaces/devurls.md
+++ b/workspaces/devurls.md
@@ -73,17 +73,19 @@ your dev URL list on the dashboard and sets the access level to **Private**.
 
 ## Programmatically accessing dev URLs
 
-If you need programmatic access to authenticated dev URLs (Private,
-Organization, or Authenticated Users), you can run the following commands:
+If you need programmatic access to authenticated dev URLs (i.e., dev URLs with
+access levels set to **private**, **organization**, or **authorized users**),
+you can run the following in the terminal:
 
 ```console
-# Generate an API token with the coder-cli
-coder@dev ~ coder tokens create devurl
+# Generate an API token with the Coder CLI
+$ coder tokens create devurl
 <TOKEN>
-# Send HTTP requests to the dev URL with the devurl_session cookie
-coder@dev ~ curl --cookie "devurl_session=<TOKEN>" <dev-url>
+# Send HTTP requests to the dev URL using the devurl_session cookie
+$ curl --cookie "devurl_session=<TOKEN>" <dev-url>
 ```
 
 ## Access via SSH port forwarding
 
-You can also access your server via [SSH port forwarding](ssh.md#forwarding-dev-urls).
+You can also access your server via
+[SSH port forwarding](ssh.md#forwarding-dev-urls).


### PR DESCRIPTION
documenting how to programmatically access authenticated dev URLs, per a customer inquiry. tested & validated on my end.