### PR TITLE
clarify: cluster guides are also for workspace providers

### DIFF
--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -4,7 +4,9 @@ description: Learn how to deploy a workspace provider.
 ---
 
 This article walks you through the process of deploying a workspace provider to
-a [Kubernetes cluster](../../setup/kubernetes/index.md).
+a Kubernetes cluster. If you do not have one, you use our
+[cluster guides](../../setup/kubernetes/index.md) to create one compatible with
+Coder.
 
 ## Dependencies
 

--- a/admin/workspace-providers/deployment.md
+++ b/admin/workspace-providers/deployment.md
@@ -4,7 +4,7 @@ description: Learn how to deploy a workspace provider.
 ---
 
 This article walks you through the process of deploying a workspace provider to
-a Kubernetes cluster. If you do not have one, you use our
+a Kubernetes cluster. If you do not have one, you can use our
 [cluster guides](../../setup/kubernetes/index.md) to create one compatible with
 Coder.
 

--- a/admin/workspace-providers/index.md
+++ b/admin/workspace-providers/index.md
@@ -22,8 +22,6 @@ specifies the Kubernetes cluster containing the Coder deployment. This allows
 users to create workspaces in the same cluster as the Coder deployment with no
 additional configuration.
 
-You cannot delete the `built-in` workspace provider.
-
 ## Remote workspace providers
 
 You can deploy a workspace provider to any existing Kubernetes cluster, enabling

--- a/setup/kubernetes/aws.md
+++ b/setup/kubernetes/aws.md
@@ -232,6 +232,10 @@ For more information, see:
 
 ## Next steps
 
+If you have already installed Coder or are using our hosted beta, you can add
+this cluster as a
+[workspace provider](../../admin/workspace-providers/deployment.md).
+
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).
 

--- a/setup/kubernetes/azure.md
+++ b/setup/kubernetes/azure.md
@@ -139,6 +139,10 @@ For more information, see:
 
 ## Next steps
 
+If you have already installed Coder or are using our hosted beta, you can add
+this cluster as a
+[workspace provider](../../admin/workspace-providers/deployment.md).
+
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).
 

--- a/setup/kubernetes/google.md
+++ b/setup/kubernetes/google.md
@@ -150,6 +150,10 @@ For more information, see:
 
 ## Next steps
 
+If you have already installed Coder or are using our hosted beta, you can add
+this cluster as a
+[workspace provider](../../admin/workspace-providers/deployment.md).
+
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).
 

--- a/setup/kubernetes/index.md
+++ b/setup/kubernetes/index.md
@@ -6,7 +6,7 @@ description: Learn how to set up a Kubernetes cluster compatible with Coder.
 This section contains guides for creating a compatible cluster on common cloud
 platforms, including Microsoft Azure, Google Cloud Platform, and Amazon Web
 Services. If you already have a Kubernetes cluster that meets Coder's
-[requirements](../requirements.md), you may wish to proceed to the [installation
+[requirements](../requirements.md), you can proceed to the [installation
 guide].
 
 ## Supported Kubernetes versions

--- a/setup/kubernetes/index.md
+++ b/setup/kubernetes/index.md
@@ -1,12 +1,13 @@
 ---
 title: Kubernetes
-description: Learn how to set up a Kubernetes cluster for your Coder deployment.
+description: Learn how to set up a Kubernetes cluster compatible with Coder.
 ---
 
 This section contains guides for creating a compatible cluster on common cloud
 platforms, including Microsoft Azure, Google Cloud Platform, and Amazon Web
-Services. If you already have a Kubernetes cluster, you may wish to proceed to
-the [installation guide].
+Services. If you already have a Kubernetes cluster that meets Coder's
+[requirements](../requirements.md), you may wish to proceed to the [installation
+guide].
 
 ## Supported Kubernetes versions
 

--- a/setup/kubernetes/k3s.md
+++ b/setup/kubernetes/k3s.md
@@ -119,6 +119,10 @@ cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 
 ## Next steps
 
+If you have already installed Coder or are using our hosted beta, you can add
+this cluster as a
+[workspace provider](../../admin/workspace-providers/deployment.md).
+
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).
 

--- a/setup/kubernetes/local-preview.md
+++ b/setup/kubernetes/local-preview.md
@@ -19,14 +19,15 @@ Before proceeding, please make sure that you have the following installed:
    [Docker Desktop][docker-desktop-url]
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 
-You will also need to
-[generate a free Coder license](https://coder.com/trial), which can be uploaded
-upon installation.
+You will also need to [generate a free Coder license](https://coder.com/trial),
+which can be uploaded upon installation.
 
 ## Limitations
 
 **We do not recommend using local previews for production deployments of
 Coder.**
+
+Local preview does not work as a workspace provider on Coder's hosted beta.
 
 ### Resource allocation and performance
 

--- a/setup/kubernetes/local-preview.md
+++ b/setup/kubernetes/local-preview.md
@@ -27,7 +27,7 @@ which you can upload upon installation.
 **We do not recommend using local previews for production deployments of
 Coder.**
 
-Local preview does not work as a workspace provider on Coder's hosted beta.
+The local preview does not work as a workspace provider for Coder's hosted beta.
 
 ### Resource allocation and performance
 

--- a/setup/kubernetes/local-preview.md
+++ b/setup/kubernetes/local-preview.md
@@ -20,7 +20,7 @@ Before proceeding, please make sure that you have the following installed:
 1. [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 
 You will also need to [generate a free Coder license](https://coder.com/trial),
-which can be uploaded upon installation.
+which you can upload upon installation.
 
 ## Limitations
 

--- a/setup/kubernetes/openshift.md
+++ b/setup/kubernetes/openshift.md
@@ -178,10 +178,6 @@ and use the base image you just created.
 
 ## Next steps
 
-If you have already installed Coder or are using our hosted beta, you can add
-this cluster as a
-[workspace provider](../../admin/workspace-providers/deployment.md).
-
 To access Coder through a secure domain, review our guides on configuring and
 using [TLS certificates](../../guides/tls-certificates/index.md).
 

--- a/setup/kubernetes/openshift.md
+++ b/setup/kubernetes/openshift.md
@@ -175,3 +175,14 @@ spec:
 When creating workspaces,
 [configure Coder to connect to the internal OpenShift registry](../../admin/registries/index.md)
 and use the base image you just created.
+
+## Next steps
+
+If you have already installed Coder or are using our hosted beta, you can add
+this cluster as a
+[workspace provider](../../admin/workspace-providers/deployment.md).
+
+To access Coder through a secure domain, review our guides on configuring and
+using [TLS certificates](../../guides/tls-certificates/index.md).
+
+Once complete, see our page on [installation](../installation.md).


### PR DESCRIPTION
We currently link to https://coder.com/docs/coder/v1.21/setup/kubernetes/ in our hosted beta emails. These changes clarify that our cluster guides also work for workspace providers.

The Setup > Kubernetes page may not be as intuitive for discoverable for people using our hosted beta, but it can be discovered via the workspace providers docs. As hosted beta becomes more popular, we may need to move the Kubernetes docs outside of the normal flow of installing Coder to support these two use cases equally.