### PR TITLE
clarify CVM auth capabilities

### DIFF
--- a/admin/workspace-management/cvms.md
+++ b/admin/workspace-management/cvms.md
@@ -141,8 +141,8 @@ container is what provides
 
 ## Images hosted in private registries
 
-Please note that CVM-enabled workspaces cannot be created using images hosted in
-a private registry unless you permit unauthenticated access to the images.
+Please note that _non-cached_ CVM workspaces cannot be created using images hosted
+in a private registry unless you permit unauthenticated access to the images.
 
 ## Image configuration
 


### PR DESCRIPTION
making this change, as cached CVMs _do_ support registry authentication methods. this is an important distinction, as we have many customers that require registry authentication.