### PR TITLE
Revert "clarify CVM auth capabilities (#578)"

### DIFF
--- a/admin/workspace-management/cvms.md
+++ b/admin/workspace-management/cvms.md
@@ -141,8 +141,8 @@ container is what provides
 
 ## Images hosted in private registries
 
-Please note that _non-cached_ CVM workspaces cannot be created using images hosted
-in a private registry unless you permit unauthenticated access to the images.
+Please note that CVM-enabled workspaces cannot be created using images hosted in
+a private registry unless you permit unauthenticated access to the images.
 
 ## Image configuration
 


### PR DESCRIPTION
This reverts commit 71be8a627d975ad64cbfece44c94893253cdd1b2.

- There was some confusion on whether CVMs can pull from private
  registries and this commit was attempted to clarify the documentation.
  The truth is CVMs can pull private image fine they just cannot use
  the node credentials.