### PR TITLE
chore: fix broken link to local preview

### DIFF
--- a/setup/kubernetes/k3s.md
+++ b/setup/kubernetes/k3s.md
@@ -7,11 +7,8 @@ This article will show you how to install K3s onto a new Ubuntu 20.04 LTS
 machine for use with Coder.
 
 [K3s](https://k3s.io/) is a lightweight Kubernetes distribution that works well
-for single-node or multi-node clusters. This guide covers the installation of
-K3s onto a new Ubuntu 20.04 LTS machine. If you want to install Coder on a local
-machine or an existing host, a [kind cluster](./kind.md) or
-[k3d cluster](https://k3d.io/) may be a better choice, as it leverages Docker to
-set up/tear down clusters with little hassle.
+for single-node or multi-node clusters. For single-user trial purposes, you may
+want to consider the options in [local preview](./local-preview.md).
 
 > This installation method is not officially supported or tested by Coder. If
 > you have questions or run into issues, feel free to reach out using our


### PR DESCRIPTION
* Condense the copy in k3s install instructions
* Link to "local preview" page, since it refers to install methods
  using both kind and Docker Desktop