### PR TITLE
chore: add changelogs for 1.21.3 and 1.22.1

### DIFF
--- a/changelog/1.21.3.md
+++ b/changelog/1.21.3.md
@@ -1,0 +1,20 @@
+---
+title: "1.21.3"
+description: "Released on 09/13/2021"
+---
+
+### Breaking changes ❗
+
+There are no breaking changes in 1.21.3.
+
+### Features ✨
+
+There are no new features in 1.21.3.
+
+### Bug fixes 🐛
+
+- infra: Fixed goroutine/memory leaks.
+
+### Security updates 🔐
+
+There are no security updates in 1.21.3.

--- a/changelog/1.21.3.md
+++ b/changelog/1.21.3.md
@@ -13,6 +13,8 @@ There are no new features in 1.21.3.
 
 ### Bug fixes 🐛
 
+> Coder v1.21.3 includes bug fixes backported from v1.22.1.
+
 - infra: Fixed goroutine/memory leaks.
 
 ### Security updates 🔐

--- a/changelog/1.22.1.md
+++ b/changelog/1.22.1.md
@@ -1,0 +1,20 @@
+---
+title: "1.22.1"
+description: "Released on 09/13/2021"
+---
+
+### Breaking changes ❗
+
+There are no breaking changes in 1.22.1.
+
+### Features ✨
+
+There are no new features in 1.22.1.
+
+### Bug fixes 🐛
+
+- infra: Fixed goroutine/memory leaks.
+
+### Security updates 🔐
+
+There are no security updates in 1.22.1.

--- a/changelog/1.22.1.md
+++ b/changelog/1.22.1.md
@@ -14,6 +14,7 @@ There are no new features in 1.22.1.
 ### Bug fixes 🐛
 
 - infra: Fixed goroutine/memory leaks.
+- infra: Fixed issue where Kubernetes labels were parsed incorrectly.
 
 ### Security updates 🔐
 

--- a/manifest.json
+++ b/manifest.json
@@ -415,7 +415,13 @@
       "path": "./changelog/index.md",
       "children": [
         {
+          "path": "./changelog/1.22.1.md"
+        },
+        {
           "path": "./changelog/1.22.0.md"
+        },
+        {
+          "path": "./changelog/1.21.3.md"
         },
         {
           "path": "./changelog/1.21.2.md"


### PR DESCRIPTION
changelog for 1.22.1 + 1.21.3 (otherwise the 1.22 version of docs won't have this)