### PR TITLE
Add upgrade steps for 1.21

### DIFF
--- a/setup/updating.md
+++ b/setup/updating.md
@@ -38,6 +38,11 @@ This guide will show you how to update your Coder deployment.
 - We recommend updating no more than one major version at a time (i.e., we
   recommend moving from 1.15 to 1.16 only).
 
+- When upgrading from a version before Coder 1.21, that version includes a new
+  networking topology that can be enabled. Each workspace provider will need
+  to be individually migrated. More information in the **Upgrade steps for 
+  1.21** section.
+
 ## Update Coder
 
 1. Retrieve the latest repository information:
@@ -219,3 +224,38 @@ If this happens, we recommend uninstalling and reinstalling:
 
    The ingress may attach to a new public IP address; if this happens, you must
    update the host and Dev URL IP addresses with your DNS provider.
+
+## Upgrade steps for 1.21
+
+Networking V2 (NetV2) was introduced in Coder version 1.21 as an optional
+operating mode for [workspace provider](/docs/admin/workspace-providers). The 
+upgrade path to get from 1.20 to 1.22 requires upgrading to 1.21, upgrading the
+workspace providers to NetV2, and then upgrading to 1.22.
+
+Steps for upgrading and configuring:
+
+1. Upgrade each minor version's highest patch as recommended above. 
+
+2. Upgrade the main Coder deployment to 1.21's most recent patch
+
+3. Upgrade workspace providers (called Satellites in newer versions) to the
+   same patch of 1.21.
+
+4. Login to Coder as Admin or Site Manager, open the "Manage" > "Workspace 
+   Providers", and enable NetV2 on the Built-in provider. 
+
+5. Enable NetV2 on workspace providers one-by-one. Validate that rebuilding a
+   workspace succeeds. There are some network configuration changes that may
+   require some DNS or TLS configuration changes in the clusters. 
+
+6. After all workspace providers are upgraded, have NetV2 enabled, and validated
+   in 1.21, upgrade to version 1.22's latest patch on the main deployment.
+
+7. The final version for workspace provider helm chart is 1.21. Upgrading to
+   that release disowns the service account from helm so uninstalling it will
+   not damage the workspace provider.
+
+8. To re-establish the Cluster as a Coder satellite, upgrade Coder to the latest
+   version and then [follow the satellite installation steps](/docs/admin/ 
+   satellites/migration).
+

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -38,10 +38,10 @@ This guide will show you how to update your Coder deployment.
 - We recommend updating no more than one major version at a time (i.e., we
   recommend moving from 1.15 to 1.16 only).
 
-- When upgrading from a version before Coder 1.21, that version includes a new
-  networking topology that can be enabled. Each workspace provider will need
-  to be individually migrated. More information in the **Upgrade steps for 
-  1.21** section.
+- Coder v1.21 introduces new networking features. To take advantage of these
+  features, you must migrate your workspace providers individually after
+  upgrading to v1.21; see [Upgrade steps for v1.21](#upgrading-to-v121) for more
+  information.
 
 ## Update Coder
 
@@ -225,37 +225,36 @@ If this happens, we recommend uninstalling and reinstalling:
    The ingress may attach to a new public IP address; if this happens, you must
    update the host and Dev URL IP addresses with your DNS provider.
 
-## Upgrade steps for 1.21
+## Upgrading to v1.21
 
-Networking V2 (NetV2) was introduced in Coder version 1.21 as an optional
-operating mode for [workspace provider](/docs/admin/workspace-providers). The 
-upgrade path to get from 1.20 to 1.22 requires upgrading to 1.21, upgrading the
-workspace providers to NetV2, and then upgrading to 1.22.
+We introduced networking V2 (a.k.a. NetV2) in v1.21 as an optional operating
+mode for [workspace providers](/docs/admin/workspace-providers). The following
+steps walk you through upgrading from an earlier version of Coder to v1.21, then
+from v1.21 to v1.22.
 
-Steps for upgrading and configuring:
+1. Upgrade the main Coder deployment to the most recent v1.21 patch (e.g.,
+   `1.21.4`).
 
-1. Upgrade each minor version's highest patch as recommended above. 
+1. Upgrade your workspace providers (called
+   [Satellites](../admin/satellites/index.md) in newer versions) to the same
+   patch of 1.21.
 
-2. Upgrade the main Coder deployment to 1.21's most recent patch
+1. Log in to Coder as a site admin or site manager. Go to **Manage** >
+   **Workspace** Providers and enable **NetV2** for the **Built-in provider**.
 
-3. Upgrade workspace providers (called Satellites in newer versions) to the
-   same patch of 1.21.
+1. Enable **NetV2** for each of your workspace providers. Validate that you can
+   rebuild your workspaces.. You may need to update DNS or TLS configurations
+   for your clusters.
 
-4. Login to Coder as Admin or Site Manager, open the "Manage" > "Workspace 
-   Providers", and enable NetV2 on the Built-in provider. 
+1. After you've upgraded all of your workspace providers, enabled NetV2, and
+   validated your changes, upgrade the main deployment to the latest v1.22
+   patch.
 
-5. Enable NetV2 on workspace providers one-by-one. Validate that rebuilding a
-   workspace succeeds. There are some network configuration changes that may
-   require some DNS or TLS configuration changes in the clusters. 
+1. Remove the workspace provider Helm chart. The final Coder version that uses
+   the workspace provider Helm chart is v1.21; because the release disowns the
+   service account from Helm, uninstalling the chart will not impact the
+   workspace providers.
 
-6. After all workspace providers are upgraded, have NetV2 enabled, and validated
-   in 1.21, upgrade to version 1.22's latest patch on the main deployment.
-
-7. The final version for workspace provider helm chart is 1.21. Upgrading to
-   that release disowns the service account from helm so uninstalling it will
-   not damage the workspace provider.
-
-8. To re-establish the Cluster as a Coder satellite, upgrade Coder to the latest
-   version and then [follow the satellite installation steps](/docs/admin/ 
-   satellites/migration).
-
+1. To re-establish the individual clusters as Coder satellites, upgrade Coder to
+   the latest version and
+   [follow the satellite installation steps](../admin/satellites/migration.md).

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -226,10 +226,12 @@ If this happens, we recommend uninstalling and reinstalling:
 
 ## Upgrading to v1.21
 
-We introduced networking V2 (a.k.a. NetV2) in v1.21 as an optional operating
-mode for [workspace providers](/docs/admin/workspace-providers). The following
-steps walk you through upgrading from an earlier version of Coder to v1.21, then
-from v1.21 to v1.22 (or later).
+We introduced [networking
+V2](https://coder.com/blog/rearchitecting-coder-networking-with-webrtc) (a.k.a.
+NetV2) in v1.21 as an optional operating mode for [workspace
+providers](/docs/admin/workspace-providers). The following steps walk you
+through upgrading from an earlier version of Coder to v1.21, then from v1.21 to
+v1.22 (or later).
 
 1. Upgrade the main Coder deployment to the most recent v1.21 patch (e.g.,
    `1.21.4`).

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -230,7 +230,7 @@ If this happens, we recommend uninstalling and reinstalling:
 We introduced networking V2 (a.k.a. NetV2) in v1.21 as an optional operating
 mode for [workspace providers](/docs/admin/workspace-providers). The following
 steps walk you through upgrading from an earlier version of Coder to v1.21, then
-from v1.21 to v1.22.
+from v1.21 to v1.22 (or later).
 
 1. Upgrade the main Coder deployment to the most recent v1.21 patch (e.g.,
    `1.21.4`).

--- a/setup/updating.md
+++ b/setup/updating.md
@@ -229,7 +229,7 @@ If this happens, we recommend uninstalling and reinstalling:
 We introduced [networking
 V2](https://coder.com/blog/rearchitecting-coder-networking-with-webrtc) (a.k.a.
 NetV2) in v1.21 as an optional operating mode for [workspace
-providers](/docs/admin/workspace-providers). The following steps walk you
+providers](../admin/workspace-providers/index.md). The following steps walk you
 through upgrading from an earlier version of Coder to v1.21, then from v1.21 to
 v1.22 (or later).
 
@@ -244,7 +244,7 @@ v1.22 (or later).
    **Workspace** Providers and enable **NetV2** for the **Built-in provider**.
 
 1. Enable **NetV2** for each of your workspace providers. Validate that you can
-   rebuild your workspaces.. You may need to update DNS or TLS configurations
+   rebuild your workspaces. You may need to update DNS or TLS configurations
    for your clusters.
 
 1. After you've upgraded all of your workspace providers, enabled NetV2, and


### PR DESCRIPTION
@khorne3 I know some of this is covered in the `admin/satellite/migration` page but I wanted to make it clear what the path to success is during upgrades. 

Please fix all the broken links. I'm not sure how cross-refs work in this SSG. 