### PR TITLE
fix previews: use node 14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Install Node Modules
         run: yarn install

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: Cache Node Modules
         uses: actions/cache@v2

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "typescript": "^4.4.2"
   },
   "engines": {
-    "node": "^12.16.0"
+    "node": "^14"
   },
   "private": true,
   "lint-staged": {


### PR DESCRIPTION
Context: Previews are failing now that coder.com uses Node v14.

If you are not using Coder to edit docs, you'll need to update to Node v14 for pre and post-commit hooks to work.