### PR TITLE
fix(workspaces): name env variable

### DIFF
--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -26,7 +26,7 @@ env | grep CODER_
         <td>Your email address</td>
     </tr>
     <tr>
-        <td><code>CODER_WORKSPACE_NAME</code></td>
+        <td><code>CODER_ENVIRONMENT_NAME</code></td>
         <td>The name of your workspace</td>
     </tr>
     <tr>


### PR DESCRIPTION
Although we renamed environments to workspaces, this ENV var
is still listed as CODER_ENVIRONMENT_NAME