### PR TITLE
fix(workspaces): add and arrange missing env vars

### DIFF
--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -34,12 +34,29 @@ env | grep CODER_
         <td>Your user name</td>
     </tr>
     <tr>
+      <td><code>CODER_URL</code></td>
+      <td>The base url of Coder</td>
+    </tr>
+    <tr>
+        <td><code>CODER_WP_NAME</code></td>
+        <td>The name of the workspace provider hosting the workspace</td>
+    </tr>
+    <tr>
+        <td><code>CODER_ASSETS_ROOT</code></td>
+        <td>The directory where coder adds coder-specific assets during
+            workspace creation, such as the coder-cli binary</td>
+    </tr>
+    <tr>
         <td><code>CODER_CPU_LIMIT</code></td>
         <td>The CPU core limit given to your workspace</td>
     </tr>
     <tr>
         <td><code>CODER_MEMORY_LIMIT</code></td>
         <td>The memory limit given to your workspace in GB</td>
+    </tr>
+    <tr>
+        <td><code>CODER_SHELL</code></td>
+        <td>The default</td>
     </tr>
     <tr>
         <td><code>CODER_IMAGE_TAG</code></td>
@@ -50,17 +67,13 @@ env | grep CODER_
         <td>The content-addressable identifier for your image</td>
     </tr>
     <tr>
-        <td><code>CODER_IMAGE_URI</code></td>
-        <td>The URI for the image used to build the workspace</td>
-    </tr>
-    <tr>
-        <td><code>CODER_WP_NAME</code></td>
-        <td>The name of the workspace provider hosting the environment</td>
-    </tr>
-    <tr>
         <td><code>CODER_RUNTIME</code></td>
         <td>The container runtime used to start the workspace (either
         `kubernetes/default` or `kubernetes/sysbox` if the workspace
         is a CVM</td>
+    </tr>
+    <tr>
+        <td><code>CODER_IMAGE_URI</code></td>
+        <td>The URI for the image used to build the workspace</td>
     </tr>
 </table>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -43,8 +43,8 @@ env | grep CODER_
     </tr>
     <tr>
         <td><code>CODER_ASSETS_ROOT</code></td>
-        <td>The directory where Coder adds Coder-specific assets during
-            workspace creation, such as the coder-cli binary</td>
+        <td>The directory where coder adds Coder-specific assets during
+            workspace creation, such as the <code>coder-cli</code> binary</td>
     </tr>
     <tr>
         <td><code>CODER_CPU_LIMIT</code></td>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -35,7 +35,7 @@ env | grep CODER_
     </tr>
     <tr>
         <td><code>CODER_URL</code></td>
-        <td>The base URL of Coder</td>
+        <td>The base URL of your Coder deployment</td>
     </tr>
     <tr>
         <td><code>CODER_WP_NAME</code></td>
@@ -43,7 +43,7 @@ env | grep CODER_
     </tr>
     <tr>
         <td><code>CODER_ASSETS_ROOT</code></td>
-        <td>The directory where coder adds coder-specific assets during
+        <td>The directory where Coder adds Coder-specific assets during
             workspace creation, such as the coder-cli binary</td>
     </tr>
     <tr>
@@ -70,6 +70,6 @@ env | grep CODER_
     </tr>
     <tr>
         <td><code>CODER_IMAGE_URI</code></td>
-        <td>The URI for the image used to build the workspace</td>
+        <td>The URI of the image used to build the workspace</td>
     </tr>
 </table>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -15,7 +15,7 @@ env | grep CODER_
 ```
 
 ## Available environment variables
-
+<!-- markdownlint-disable MD044 -->
 <table>
     <tr>
         <th>Environment variable</th>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -55,10 +55,6 @@ env | grep CODER_
         <td>The memory limit given to your workspace in GB</td>
     </tr>
     <tr>
-        <td><code>CODER_SHELL</code></td>
-        <td>The default</td>
-    </tr>
-    <tr>
         <td><code>CODER_IMAGE_TAG</code></td>
         <td>The image tag used to create your workspace</td>
     </tr>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -34,8 +34,8 @@ env | grep CODER_
         <td>Your user name</td>
     </tr>
     <tr>
-      <td><code>CODER_URL</code></td>
-      <td>The base url of Coder</td>
+        <td><code>CODER_URL</code></td>
+        <td>The base URL of Coder</td>
     </tr>
     <tr>
         <td><code>CODER_WP_NAME</code></td>

--- a/workspaces/variables.md
+++ b/workspaces/variables.md
@@ -65,8 +65,8 @@ env | grep CODER_
     <tr>
         <td><code>CODER_RUNTIME</code></td>
         <td>The container runtime used to start the workspace (either
-        `kubernetes/default` or `kubernetes/sysbox` if the workspace
-        is a CVM</td>
+        <code>kubernetes/default</code> or <code>kubernetes/sysbox</code>
+        if the workspace is a CVM</td>
     </tr>
     <tr>
         <td><code>CODER_IMAGE_URI</code></td>


### PR DESCRIPTION
Need to fill in the details of a few of them. Arranged them to match the output given by 

```
env | grep CODER_
```

![env-vars](https://user-images.githubusercontent.com/11184711/135548416-78a68ceb-30c9-413f-b1a3-d1ae82a5679d.JPG)
