### PR TITLE
chore: disable mdlint for select pages

### DIFF
--- a/setup/kubernetes/index.md
+++ b/setup/kubernetes/index.md
@@ -24,10 +24,12 @@ minimum baseline version of Kubernetes supports the necessary features in a
 stable version. We follow this policy to ensure that Coder stops using
 deprecated features before they are removed from new versions of Kubernetes.
 
+<!-- markdownlint-disable -->
 [compatible kubernetes cluster]: ../requirements.md
 [kubernetes upstream version support policy]:
   https://kubernetes.io/docs/setup/release/version-skew-policy/
 [installation guide]: ../installation.md
+<!-- markdownlint-restore -->
 
 ## Incompatible Kubernetes distributions
 

--- a/setup/kubernetes/local-preview.md
+++ b/setup/kubernetes/local-preview.md
@@ -3,6 +3,8 @@ title: "Local preview"
 description: Set up a Coder deployment locally for testing.
 ---
 
+<!-- markdownlint-disable -->
+
 Coder is typically deployed to a remote data center, but you can use
 [Docker][docker-url] to create a lightweight preview deployment of Coder.
 


### PR DESCRIPTION
we need a workaround for when we have proper nouns in strings used for links; at this time, am disabling mdlint on those pages so all the tests stop failing.