### PR TITLE
chore: add explanation to user roles

### DIFF
--- a/admin/access-control/user-roles.md
+++ b/admin/access-control/user-roles.md
@@ -39,6 +39,20 @@ There are four roles available:
     </tbody>
 </table>
 
+### Additive permissions
+
+The following tables detail what permissions Coder grants to each of the four
+roles, but a summary of the roles are:
+
+- All users are (or have the permissions of) a **member**
+- An auditor has the permissions of a member, plus the ability to work with
+  audit logs
+- A site manager has the permissions of a member or an auditor, please
+  additional administrative rights
+- A site admin has the permissions of a member, auditor, and site manager, as
+  well as additional admin rights (e.g., creating site managers, access to API
+  keys).
+
 ### Site admin permissions
 
 <table>


### PR DESCRIPTION
I played with a bunch of different charts, including [this one](https://docs.google.com/spreadsheets/d/1bQG5GTZML3lCQPpKMAEy2pBIeY40_eJkK6h9pWPuLF0/edit?usp=sharing), but in the end, I didn't think the added complexity would be helpful to anyone reading our user perms doc. So, I just added a brief summary of how the permissions are additive (mostly).

Will also add the automated tables when we have that ready.