### PR TITLE
chore: add Kubernetes support notice to changelog

### DIFF
--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -3,9 +3,9 @@ title: "1.25.0"
 description: "Released on 11/17/2021"
 ---
 
-The final patch release of Kubernetes 1.19 was published on October 28, 2021. As
-such, and in keeping with Coder's [version support policy], subsequent release
-versions will require Kubernetes 1.20 or later.
+> The final patch release of Kubernetes 1.19 was published on 28 October 2021.
+> As such, Coder v1.25 (and later) require the use of Kubernetes v1.20+. See
+> Coder's [version support policy] for more information.
 
 [version support policy]:
   ../setup/Kubernetes/index.md#supported-Kubernetes-versions

--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -4,8 +4,8 @@ description: "Released on 11/17/2021"
 ---
 
 > The final patch release of Kubernetes 1.19 was published on 28 October 2021.
-> As such, the _subsequent_ versions of Coder (v1.26 later) will require the use
-> of Kubernetes 1.20 or later. See Coder's [version support policy] for more
+> As such, the _subsequent_ versions of Coder (v1.26 and later) will require the
+> use of Kubernetes 1.20 or later. See Coder's [version support policy] for more
 > information.
 
 <!-- Turn off linting to avoid changing the link -->

--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -5,10 +5,10 @@ description: "Released on 11/17/2021"
 
 The final patch release of Kubernetes 1.19 was published on October 28, 2021. As
 such, and in keeping with Coder's [version support policy], subsequent release
-versions will require Kubernetes 1.20.
+versions will require Kubernetes 1.20 or later.
 
 [version support policy]:
-  ../setup/kubernetes/index.md#supported-kubernetes-versions
+  ../setup/Kubernetes/index.md#supported-Kubernetes-versions
 
 ### Breaking changes ❗
 

--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -7,8 +7,13 @@ description: "Released on 11/17/2021"
 > As such, Coder v1.26 (and later) will require the use of Kubernetes 1.20 or
 > later. See Coder's [version support policy] for more information.
 
+<!-- Turn off linting to avoid changing the link -->
+<!-- markdownlint-disable MD044 -->
+
 [version support policy]:
-  ../setup/Kubernetes/index.md#supported-Kubernetes-versions
+  ../setup/kubernetes/index.md#supported-kubernetes-versions
+
+<!-- markdownlint-enable MD044 -->
 
 ### Breaking changes ❗
 

--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -3,6 +3,13 @@ title: "1.25.0"
 description: "Released on 11/17/2021"
 ---
 
+The final patch release of Kubernetes 1.19 was published on October 28, 2021. As
+such, and in keeping with Coder's [version support policy], subsequent release
+versions will require Kubernetes 1.20.
+
+[version support policy]:
+  ../setup/kubernetes/index.md#supported-kubernetes-versions
+
 ### Breaking changes ❗
 
 There are no breaking changes in 1.25.0.

--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -4,8 +4,9 @@ description: "Released on 11/17/2021"
 ---
 
 > The final patch release of Kubernetes 1.19 was published on 28 October 2021.
-> As such, Coder v1.26 (and later) will require the use of Kubernetes 1.20 or
-> later. See Coder's [version support policy] for more information.
+> As such, the _subsequent_ versions of Coder (v1.26 later) will require the use
+> of Kubernetes 1.20 or later. See Coder's [version support policy] for more
+> information.
 
 <!-- Turn off linting to avoid changing the link -->
 <!-- markdownlint-disable MD044 -->

--- a/changelog/1.25.0.md
+++ b/changelog/1.25.0.md
@@ -4,8 +4,8 @@ description: "Released on 11/17/2021"
 ---
 
 > The final patch release of Kubernetes 1.19 was published on 28 October 2021.
-> As such, Coder v1.25 (and later) require the use of Kubernetes v1.20+. See
-> Coder's [version support policy] for more information.
+> As such, Coder v1.26 (and later) will require the use of Kubernetes 1.20 or
+> later. See Coder's [version support policy] for more information.
 
 [version support policy]:
   ../setup/Kubernetes/index.md#supported-Kubernetes-versions


### PR DESCRIPTION
Add a notice indicating that this is the final release of Coder
that will support Kubernetes 1.19, in keeping with our version
support policy and the Kubernetes upstream release schedule.