### PR TITLE
fix: Coder image workflow wasn't working

### DIFF
--- a/.github/workflows/build_coder_image.yaml
+++ b/.github/workflows/build_coder_image.yaml
@@ -10,9 +10,6 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     steps:
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v2.1
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Login to DockerHub
@@ -28,7 +25,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/your-project:latest, ${{ secrets.DOCKERHUB_USERNAME }}/your-project:${{ steps.vars.outputs.sha_short }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/docs:latest, ${{ secrets.DOCKERHUB_USERNAME }}/docs:${{ steps.vars.outputs.sha_short }}
           context: .coder/
           file: .coder/Dockerfile
       - name: Image digest

--- a/.github/workflows/build_coder_image.yaml
+++ b/.github/workflows/build_coder_image.yaml
@@ -5,6 +5,7 @@ on:
       - "main"
     paths:
       - ".coder/**" # only run the action when .coder/ folder has been modified
+      - ".github/workflows/**" # run when a GitHub workflow has been modified
   workflow_dispatch:
 jobs:
   build-image:


### PR DESCRIPTION
`tj-actions/changed-files` was not being used, so I removed it.

```
Error : .github#L1
tj-actions/changed-files@v2.1 is not allowed to be used in cdr/docs. Actions in this workflow must be: within a repository owned by cdr, created by GitHub, verified in the GitHub Marketplace or match the following: marocchino/sticky-pull-request-comment@*, styfle/cancel-workflow-action@*, w3f/action-find-old-files@*, 8398a7/action-slack@*.
```

Uses the proper image name as well.